### PR TITLE
release 0.5.0 with 4 bugfixes

### DIFF
--- a/DESIGN.rst
+++ b/DESIGN.rst
@@ -1,5 +1,5 @@
 TelnetStream
-------------
+============
 
 feed_byte called by telnet server should be a coroutine
 receiving data by send. It should yield 'is_oob', or 'slc_received',
@@ -13,6 +13,30 @@ base protocol.  The given code was written before these methods became
 available in asyncio (then, tulip).  We need to accommodate the new
 availabilities.
 
+On STATUS rfc
+-------------
+We do everything fine because we negotiate fine so far, but what exactly are
+we expected to do when the distant end's concept of our negotiation STATUS
+disagrees with our own? Match theirs, re-negotiate .. ?
+
+On Linemode
+-----------
+Now we seem to completion of linemode acknowledgement state loop for both
+client and server, however, what do we do in the case of a server making a
+suggestion (no ack bit set) that a "user" downstream of our API would
+suggest to refuse? We would rather supply a table of 3-divider choice,
+(allow-any/force-on/force-off), where force-on and force-off would cause
+such bits to be set back on again before acknowledging return.
+
+currently, we just choose whatever they suggest, always, in
+_handle_sb_linemode_mode.
+
+as a server, we simply honor whatever is given.  This is also
+problematic in some designers may wish to implement shells
+that specifically do not honor some parts of the bitmask, we
+must provide them an any/force-on/force-off mode table interface.
+
+
 On Encoding
 -----------
 
@@ -20,3 +44,11 @@ currently we determine 'CHARSET': 'utf8' because we cannot correctly
 determine the first part of LANG (en_us.UTF-8, for example).  It should
 be possible, in a derived (demo) application, to determine the region
 code by geoip (maxmind database, etc).
+
+On Constants, debug logging
+---------------------------
+
+Like our C counterparts, we should use something more advanced than
+a #define / enumeration, so that when printed, print their NAME --
+when sent as bytes, send their raw value.
+

--- a/bin/telnet-client
+++ b/bin/telnet-client
@@ -55,7 +55,7 @@ def start_client(loop, log, Client, host, port, cp437=False, send_cr=False):
             protocol.shell.write(ucs)
 
     loop.add_reader(sys.stdin.buffer.fileno(), keyboard_input)
-    yield from protocol.waiter
+    yield from protocol.waiter_closed
 
 
 def main():

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,7 @@
   * bugfix: linemode MODE is now acknowledged.
   * bugfix: default stream handler sends 80 x 24 in cols x rows, not 24 x 80.
   * bugfix: waiter_closed future on client defaulted to wrong type.
+  * bugfix: telnet shell (TelSh) no longer paints over final exception line.
 
 0.4.0
   * bugfix: cannot connect to IPv6 address as client.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,3 +1,8 @@
+0.5.0
+  * bugfix: linemode MODE is now acknowledged.
+  * bugfix: default stream handler sends 80 x 24 in cols x rows, not 24 x 80.
+  * bugfix: waiter_closed future on client defaulted to wrong type.
+
 0.4.0
   * bugfix: cannot connect to IPv6 address as client.
   * change: TelnetClient.CONNECT_DEFERED class attribute renamed DEFERRED.

--- a/telnetlib3/client.py
+++ b/telnetlib3/client.py
@@ -357,7 +357,7 @@ class TelnetClient(asyncio.protocols.Protocol):
                 try:
                     codec = codecs.lookup(offer)
                 except LookupError as err:
-                    self.log.debug('{}'.format(err))
+                    self.log.info('LookupError: {}'.format(err))
                 else:
                     if (codec.name == self.env['CHARSET'] or not selected):
                         self.env['CHARSET'] = codec.name

--- a/telnetlib3/telopt.py
+++ b/telnetlib3/telopt.py
@@ -58,7 +58,8 @@ class TelnetStream:
         'UTF-8', 'UTF-16', 'US-ASCII', 'LATIN1', 'BIG5',
         'GBK', 'SHIFTJIS', 'GB18030', 'KOI8-R', 'KOI8-U',
     ) + tuple(
-        'ISO8859-{}'.format(iso) for iso in range(16)
+        # "Part 12 was slated for Latin/Devanagari, but abandoned in 1997"
+        'ISO8859-{}'.format(iso) for iso in range(1, 16) if iso != 12
     ) + tuple(
         'CP{}'.format(cp) for cp in (
             154, 437, 500, 737, 775, 850, 852, 855, 856, 857,

--- a/telnetlib3/telsh.py
+++ b/telnetlib3/telsh.py
@@ -480,9 +480,11 @@ class Telsh():
         or @property ``autocomplete_cmdset`` is used.
         """
         self.log.debug('tab_received: {!r}'.format(input))
+
         # dynamic injection of variables for set command,
         cmd, args = input.rstrip(), []
         table = self.autocomplete_cmdset if table is None else table
+
         # inject session variables for set command,
         if 'set' in table:
             table['set'] = collections.OrderedDict([
@@ -753,8 +755,10 @@ class Telsh():
         return ('{}'.format(prompt_eval(self, ps)))
 
     def display_exception(self, *exc_info):
-        """ Dispaly exception to client when ``show_traceback`` is True,
-            forward copy server log at debug and info levels.
+        """
+        Display exception to client when ``show_traceback`` is True.
+
+        Forward-copy to server log at DEBUG and INFO levels.
         """
         tbl_exception = (
             traceback.format_tb(exc_info[2]) +
@@ -762,10 +766,14 @@ class Telsh():
         for num, tb in enumerate(tbl_exception):
             tb_msg = tb.splitlines()
             if self.show_traceback:
-                self.stream.write('\r\n' + '\r\n'.join(
-                    self.standout(row.rstrip())
-                    if num == len(tbl_exception) - 1
-                    else row.rstrip() for row in tb_msg))
+                self.stream.write(u'\r\n'.join(
+                    (u'',
+                     '\r\n'.join(
+                         self.standout(row.rstrip())
+                         if num == len(tbl_exception) - 1
+                         else row.rstrip()
+                         for row in tb_msg),
+                     u'\r\n')))
             tbl_srv = [row.rstrip() for row in tb_msg]
             for line in tbl_srv:
                 self.log.log(logging.ERROR, line)
@@ -1125,7 +1133,7 @@ def autocomplete(table, cycle, buf, cmd, *args):
             table : collections.OrderedDict, cycle : bool,
             buf : string, cmd : string, *args) -> (buf, bool)
 
-    Recursive autocompete function. This provides no "found last match"
+    Recursive auto-complete function. This provides no "found last match"
     state tracking, but rather simply cycles 'next match' when cycle
     is True, meaning 's'<tab> -> 'set', then, subsequent <tab> -> 'status'.
     """
@@ -1154,19 +1162,22 @@ def autocomplete(table, cycle, buf, cmd, *args):
                         postfix(auto_cmd),
                         escape_quote(args))
                     return (buf, False)
+
                 # first-time exact match,
                 if not cycle:
                     return (buf, True)
+
                 # cycle next match
                 ptr = 0 if ptr + 1 == len(auto_cmds) - 1 else ptr + 1
                 buf = ''.join((postfix(buf), auto_cmds[ptr]))
                 return (buf, True)
             else:
-                # match at this step, have/will args, recruse;
+                # match at this step, have/will args, recurse;
                 buf = ''.join((postfix(buf), auto_cmd,))
                 _cmd = args[0] if args else ''
                 return autocomplete(
                     table[auto_cmd], cycle, buf, _cmd, *args[1:])
+
         elif auto_cmd.lower().startswith(cmd.lower()):
             # partial match, error if arguments not valid,
             args_ok = bool(not args or args and has_args)
@@ -1174,6 +1185,7 @@ def autocomplete(table, cycle, buf, cmd, *args):
             if args or has_args:
                 buf = ''.join((postfix(buf), escape_quote(args)))
             return (buf, args_ok)
+
     # no matches
     buf = '{}{}{}'.format(
         postfix(buf), cmd, escape_quote(args))


### PR DESCRIPTION
  * bugfix: linemode MODE is now acknowledged.
  * bugfix: default stream handler sends 80 x 24 in cols x rows, not 24 x 80.
  * bugfix: waiter_closed future on client defaulted to wrong type.
  * bugfix: telnet shell (TelSh) no longer paints over final exception line.