### PR TITLE
Break Circular References #43 

### DIFF
--- a/telnetlib3/server.py
+++ b/telnetlib3/server.py
@@ -111,7 +111,7 @@ class TelnetServer(server_base.BaseServer):
         encoding = self.encoding(outgoing=True, incoming=True)
         if not self.waiter_encoding.done() and result:
             self.log.debug('encoding complete: {0!r}'.format(encoding))
-            self.waiter_encoding.set_result(self)
+            self.waiter_encoding.set_result(True)
 
         elif (not self.waiter_encoding.done() and
               self.writer.remote_option.get(TTYPE) is False):
@@ -120,13 +120,13 @@ class TelnetServer(server_base.BaseServer):
             # the distant end would not support it, declaring encoding failed.
             self.log.debug('encoding failed after {0:1.2f}s: {1}'
                            .format(self.duration, encoding))
-            self.waiter_encoding.set_result(self)
+            self.waiter_encoding.set_result(True)
             return parent
 
         elif not self.waiter_encoding.done() and final:
             self.log.debug('encoding failed after {0:1.2f}s: {1}'
                            .format(self.duration, encoding))
-            self.waiter_encoding.set_result(self)
+            self.waiter_encoding.set_result(True)
             return parent
 
         return parent and result

--- a/telnetlib3/server.py
+++ b/telnetlib3/server.py
@@ -14,6 +14,7 @@ import argparse
 import asyncio
 import logging
 import signal
+from weakref import proxy
 
 # local
 from . import server_base
@@ -111,7 +112,7 @@ class TelnetServer(server_base.BaseServer):
         encoding = self.encoding(outgoing=True, incoming=True)
         if not self.waiter_encoding.done() and result:
             self.log.debug('encoding complete: {0!r}'.format(encoding))
-            self.waiter_encoding.set_result(True)
+            self.waiter_encoding.set_result(proxy(self))
 
         elif (not self.waiter_encoding.done() and
               self.writer.remote_option.get(TTYPE) is False):
@@ -120,13 +121,13 @@ class TelnetServer(server_base.BaseServer):
             # the distant end would not support it, declaring encoding failed.
             self.log.debug('encoding failed after {0:1.2f}s: {1}'
                            .format(self.duration, encoding))
-            self.waiter_encoding.set_result(True)
+            self.waiter_encoding.set_result(proxy(self))
             return parent
 
         elif not self.waiter_encoding.done() and final:
             self.log.debug('encoding failed after {0:1.2f}s: {1}'
                            .format(self.duration, encoding))
-            self.waiter_encoding.set_result(True)
+            self.waiter_encoding.set_result(proxy(self))
             return parent
 
         return parent and result

--- a/telnetlib3/stream_writer.py
+++ b/telnetlib3/stream_writer.py
@@ -182,6 +182,17 @@ class TelnetWriter(asyncio.StreamWriter):
 
     # Base protocol methods
 
+    def close(self):
+        super().close()
+        # break circular refs
+        self._ext_callback.clear()
+        self._ext_send_callback.clear()
+        self._slc_callback.clear()
+        self._iac_callback.clear()
+        self.fn_encoding = None
+        self._protocol = None
+        self._transport = None
+
     def __repr__(self):
         """Description of stream encoding state."""
         info = ['TelnetWriter']


### PR DESCRIPTION
Solve memory leaks by breaking Circular References on writer.close() and connection lost. 
This solves the issue #43 

Still working on a test