### PR TITLE
Add Generic Mud Communication Protocol support

### DIFF
--- a/telnetlib3/server_base.py
+++ b/telnetlib3/server_base.py
@@ -23,10 +23,6 @@ class BaseServer(asyncio.streams.FlowControlMixin, asyncio.Protocol):
     _transport = None
     _advanced = False
     _closing = False
-    _reader_factory = TelnetReader
-    _reader_factory_encoding = TelnetReaderUnicode
-    _writer_factory = TelnetWriter
-    _writer_factory_encoding = TelnetWriterUnicode
 
     def __init__(
         self,
@@ -38,6 +34,10 @@ class BaseServer(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         force_binary=False,
         connect_maxwait=4.0,
         limit=None,
+        reader_factory=TelnetReader,
+        reader_factory_encoding=TelnetReaderUnicode,
+        writer_factory=TelnetWriter,
+        writer_factory_encoding=TelnetWriterUnicode,
     ):
         """Class initializer."""
         super().__init__()
@@ -45,6 +45,11 @@ class BaseServer(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         self._encoding_errors = encoding_errors
         self.force_binary = force_binary
         self._extra = dict()
+
+        self._reader_factory = reader_factory
+        self._reader_factory_encoding = reader_factory_encoding
+        self._writer_factory = writer_factory
+        self._writer_factory_encoding = writer_factory_encoding
 
         #: a future used for testing
         self._waiter_connected = _waiter_connected or asyncio.Future()

--- a/telnetlib3/stream_writer.py
+++ b/telnetlib3/stream_writer.py
@@ -27,6 +27,7 @@ from .telopt import (
     EOR,
     ESC,
     GA,
+    GMCP,
     IAC,
     INFO,
     IP,
@@ -1427,6 +1428,7 @@ class TelnetWriter(asyncio.StreamWriter):
             CHARSET,
             NAWS,
             STATUS,
+            GMCP,
         ):
 
             # first time we've agreed, respond accordingly.
@@ -1633,6 +1635,7 @@ class TelnetWriter(asyncio.StreamWriter):
             XDISPLOC: self._handle_sb_xdisploc,
             STATUS: self._handle_sb_status,
             COM_PORT_OPTION: self._handle_sb_comport,
+            GMCP: self._handle_sb_gmcp,
         }.get(cmd)
         if fn_call is None:
             raise ValueError(
@@ -2470,6 +2473,21 @@ class TelnetWriter(asyncio.StreamWriter):
 
         self.log.debug(
             "SB unhandled: cmd={}, buf={!r}".format(name_command(COM_PORT_OPTION), buf)
+        )
+
+        return
+
+    def _handle_sb_gmcp(self, buf):
+        """
+        Callback handles request for Generic Mud Communication Protocol (GMCP).
+
+        This callback simply logs the subnegotiation but does not perform any action.
+
+        :param bytes buf: bytes following IAC SB GMCP.
+        """
+
+        self.log.debug(
+            "SB unhandled: cmd={}, buf={!r}".format(name_command(GMCP), b"".join(buf))
         )
 
         return

--- a/telnetlib3/telopt.py
+++ b/telnetlib3/telopt.py
@@ -109,6 +109,7 @@ __all__ = (
     "LOGOUT",
     "MCCP2_COMPRESS",
     "MCCP_COMPRESS",
+    "GMCP",
     "NAMS",
     "NAOCRD",
     "NAOFFD",
@@ -176,6 +177,7 @@ __all__ = (
     bytes([const]) for const in range(1, 8)
 )
 (MCCP_COMPRESS, MCCP2_COMPRESS) = (bytes([85]), bytes([86]))
+GMCP = bytes([201])
 
 #: List of globals that may match an iac command option bytes
 _DEBUG_OPTS = dict(
@@ -226,6 +228,7 @@ _DEBUG_OPTS = dict(
             "SNDLOC",
             "MCCP_COMPRESS",
             "MCCP2_COMPRESS",
+            "GMCP",
             "ENCRYPT",
             "AUTHENTICATION",
             "TN3270E",


### PR DESCRIPTION
GMCP is a common method for MUD servers and clients to exchange out of band data.

For more detail, see: https://www.gammon.com.au/gmcp