### PR TITLE
Expunge last remnants of Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Introduction
 ============
 
 telnetlib3 is a Telnet Client and Server library for python.  This project
-requires python 3.6 and later, using the asyncio_ module.
+requires python 3.7 and later, using the asyncio_ module.
 
 .. _asyncio: http://docs.python.org/3.11/library/asyncio.html
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands = coveralls --verbose --rcfile={toxinidir}/.coveragerc
 [testenv:sa]
 # perform static analysis and style enforcement
 # Disabled: needs to be brought up-to-date
-basepython = python3.6
+basepython = python3.11
 deps = -rrequirements-tests.txt
        -rrequirements-analysis.txt
 commands = python -m compileall -fq {toxinidir}/telnetlib3


### PR DESCRIPTION
Closes #66.