### PR TITLE
stream_reader.py: import sys

### DIFF
--- a/telnetlib3/stream_reader.py
+++ b/telnetlib3/stream_reader.py
@@ -1,5 +1,6 @@
 """Module provides class TelnetReader and TelnetReaderUnicode."""
 # std imports
+import sys
 import codecs
 import asyncio
 import logging


### PR DESCRIPTION
open_connection throws a NameError exception and freezes when asyncio.run is called with debug=True. To reproduce issue:

```
import asyncio
import telnetlib3

async def open_connection():
  return await telnetlib3.open_connection("127.0.0.1", "12345")

if __name__ == "__main__":
    asyncio.run(open_connection(), debug=True)
```