### PR TITLE
feat: Add `readuntil_pattern` to support regex matching

### DIFF
--- a/telnetlib3/tests/test_reader.py
+++ b/telnetlib3/tests/test_reader.py
@@ -1,5 +1,6 @@
 # std imports
 import asyncio
+import re
 import string
 
 # 3rd party
@@ -316,3 +317,119 @@ async def test_telnet_reader_read_beyond_limit_bytes(bind_host, unused_tcp_port)
     assert client_reader._limit == limit
     value = await asyncio.wait_for(client_reader.read(), 0.5)
     assert value == b"x" * (limit + 1)
+
+
+async def test_telnet_reader_readuntil_pattern(bind_host, unused_tcp_port):
+    """Ensure TelnetReader.readuntil_pattern,
+    especially IncompleteReadError and LimitOverrunError."""
+
+    # given
+    text = b"""
+Router> enable
+Router# configure terminal
+Router(config)# hostname Router-Telnetlib
+Router-Telnetlib(config)# exit
+Router-Telnetlib# exit
+Router>
+"""
+    meaningless_data: bytes = b"meaningless" * 2**16
+    data: bytes = text + meaningless_data + b"\n"
+
+    # Byte pattern to match command prompt
+    pattern = re.compile(rb"\S+[>#]")
+    limit = 30
+
+    def shell(_, writer):
+        writer.write(data)
+        writer.close()
+
+    await telnetlib3.create_server(
+        host=bind_host,
+        port=unused_tcp_port,
+        connect_maxwait=0.05,
+        shell=shell,
+        encoding=False,
+        limit=limit,
+    )
+
+    client_reader, _ = await telnetlib3.open_connection(
+        host=bind_host,
+        port=unused_tcp_port,
+        connect_minwait=0.05,
+        encoding=False,  # type: ignore
+        limit=limit,
+    )
+    assert client_reader is not None
+
+    # Test successful read within limit
+    result = await client_reader.readuntil_pattern(pattern)
+    assert result == b"\nRouter>"
+
+    result = await client_reader.readuntil_pattern(pattern)
+    assert result == b" enable\nRouter#"
+
+    # Test LimitOverrunError: pattern found but data chunk exceeds limit
+    # Next chunk ' configure terminal\nRouter(config)#' is 35 bytes long, exceeding limit (30)
+    with pytest.raises(asyncio.LimitOverrunError) as exc_info:
+        await client_reader.readuntil_pattern(pattern)
+
+    assert "Pattern is found, but chunk is longer than limit" in str(exc_info.value)
+    # consumed should be the expected length of the oversized chunk
+    assert exc_info.value.consumed == 35
+
+    # Test LimitOverrunError: buffer exceeds limit, pattern not found
+    # Oversized chunk remains in buffer, buffer length now exceeds limit
+    # Searching for a non-existent pattern should trigger another LimitOverrunError
+    with pytest.raises(asyncio.LimitOverrunError) as exc_info:
+        await client_reader.readuntil_pattern(re.compile(b"non-existent"))
+
+    assert "Pattern not found, and buffer exceed the limit" in str(exc_info.value)
+    # consumed should be the current buffer length
+    assert exc_info.value.consumed > limit
+
+    # Clean up oversized chunk for further testing by reading it in parts
+    # First, read the overflow portion based on the previous exception info
+    expected = b" configure terminal\nRouter(config)#"
+    oversized_chunk = await client_reader.read(len(expected))
+    assert oversized_chunk == expected
+
+    expected = b" hostname Router-Telnetlib\nRouter-Telnetlib(config)#"
+    oversized_chunk = await client_reader.read(len(expected))
+    assert oversized_chunk == expected
+
+    result = await client_reader.readuntil_pattern(pattern)
+    assert result == b" exit\nRouter-Telnetlib#"
+
+    result = await client_reader.readuntil_pattern(pattern)
+    assert result == b" exit\nRouter>"
+
+    # Consume meaningless data
+    expected = b"\n" + meaningless_data
+    result = await client_reader.readexactly(len(expected))
+    assert result == expected
+
+    # Test IncompleteReadError: EOF before pattern found
+    # Server has closed connection, only a newline remains
+    with pytest.raises(asyncio.IncompleteReadError) as exc_info:
+        await client_reader.readuntil_pattern(pattern)
+
+    # 'partial' should contain remaining data
+    assert exc_info.value.partial == b"\n"
+    assert exc_info.value.expected is None
+
+    # After IncompleteReadError, buffer is cleared
+    # Subsequent reads should also fail with empty partial buffer
+    with pytest.raises(asyncio.IncompleteReadError) as exc_info:
+        await client_reader.readuntil_pattern(pattern)
+    assert exc_info.value.partial == b""
+
+    # Test ValueError for invalid pattern type
+    with pytest.raises(ValueError, match="pattern should be a re.Pattern object"):
+        await client_reader.readuntil_pattern(None)  # type: ignore
+
+    with pytest.raises(ValueError, match="Only bytes patterns are supported"):
+        await client_reader.readuntil_pattern(re.compile("this is a string pattern"))
+
+    client_reader.set_exception(asyncio.CancelledError())
+    with pytest.raises(asyncio.CancelledError):
+        await client_reader.readuntil_pattern(pattern)


### PR DESCRIPTION
Fixes: #88

This pull request introduces a new `readuntil_pattern` method to the `TelnetReader` class, enabling users to read from the stream until a regular expression pattern is matched. This enhancement addresses the limitation of the existing `readuntil` function, which only accepts fixed byte strings, making it difficult to handle dynamic server responses where the exact output is unpredictable.

**Key features of `readuntil_pattern`:**

*   **Regex-based Stream Reading:** Accepts a compiled bytes pattern (`re.Pattern`) to provide flexible and powerful stream matching.
*   **Error Handling:**
    *   Raises `asyncio.LimitOverrunError` if a matched block of data exceeds the configured stream limit.
    *   Raises `asyncio.IncompleteReadError` if the end-of-file (EOF) is reached before the pattern is found.
*   **Input Validation:** Ensures that the provided pattern is a valid compiled bytes pattern (`re.Pattern`).

A comprehensive test suite has been added to verify the functionality of `readuntil_pattern`, covering successful matching, error conditions (`LimitOverrunError`, `IncompleteReadError`), and argument validation.