### PR TITLE
2.5.0: Several improvements from scanning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,10 @@ program.
     telnetlib3-server
     # or custom port and ip and shell
     telnetlib3-server 0.0.0.0 1984 --shell=bin.server_wargame.shell
-    # run an external program with a pseudo-terminal
-    telnetlib3-server --pty-exec /bin/bash --pty-raw -- --login
-    # or a simple linemode program, bc (calculator)
-    telnetlib3-server --pty-exec /bin/bc
+    # run an external program with a pseudo-terminal (raw mode is default)
+    telnetlib3-server --pty-exec /bin/bash -- --login
+    # or a linemode program, bc (calculator)
+    telnetlib3-server --pty-exec /bin/bc --line-mode
 
 
 There are also fingerprinting CLIs, ``telnetlib3-fingerprint`` and

--- a/docs/guidebook.rst
+++ b/docs/guidebook.rst
@@ -205,6 +205,32 @@ and utf-8 support.
 The same applies to clients -- ``open_connection(..., encoding=False)``
 returns a ``(TelnetReader, TelnetWriter)`` pair that works with ``bytes``.
 
+Retro BBS Encodings
+~~~~~~~~~~~~~~~~~~~
+
+telnetlib3 includes custom codecs for retro computing platforms commonly
+found on telnet BBS systems:
+
+- **ATASCII** (``--encoding=atascii``) -- Atari 8-bit computers (400, 800,
+  XL, XE).  Graphics characters at 0x00-0x1F, card suits, box drawing, and
+  an inverse-video range at 0x80-0xFF.  The ATASCII end-of-line character
+  (0x9B) maps to newline.  Aliases: ``atari8bit``, ``atari_8bit``.
+- **PETSCII** (``--encoding=petscii``) -- Commodore 64/128 shifted
+  (lowercase) mode.  Lowercase a-z at 0x41-0x5A, uppercase A-Z at
+  0xC1-0xDA.  Aliases: ``cbm``, ``commodore``, ``c64``, ``c128``.
+- **Atari ST** (``--encoding=atarist``) -- Atari ST character set with
+  extended Latin, Greek, and math symbols.  Alias: ``atari``.
+
+These encodings use bytes 0x80-0xFF for standard glyphs, which conflicts
+with the telnet protocol's default 7-bit NVT mode.  When any of these
+encodings is selected, ``--force-binary`` is automatically enabled so that
+high-bit bytes are transmitted without requiring BINARY option negotiation::
+
+    telnetlib3-client --encoding=atascii area52.tk 5200
+    telnetlib3-client --encoding=petscii bbs.example.com 6400
+
+``telnetlib3-fingerprint`` also decode banners with these encodings.
+
 Line Endings
 ~~~~~~~~~~~~
 

--- a/docs/guidebook.rst
+++ b/docs/guidebook.rst
@@ -224,12 +224,30 @@ found on telnet BBS systems:
 These encodings use bytes 0x80-0xFF for standard glyphs, which conflicts
 with the telnet protocol's default 7-bit NVT mode.  When any of these
 encodings is selected, ``--force-binary`` is automatically enabled so that
-high-bit bytes are transmitted without requiring BINARY option negotiation::
+high-bit bytes are transmitted without requiring BINARY option negotiation.
+
+PETSCII inline color codes are translated to ANSI 24-bit RGB using the
+VIC-II C64 palette, and cursor control codes (up/down/left/right, HOME,
+CLR, DEL) are translated to ANSI sequences.  ATASCII control character
+glyphs (cursor movement, backspace, clear screen) are similarly translated.
+
+Keyboard input is also mapped: arrow keys, backspace, delete, and enter
+produce the correct raw bytes for each encoding::
 
     telnetlib3-client --encoding=atascii area52.tk 5200
     telnetlib3-client --encoding=petscii bbs.example.com 6400
 
-``telnetlib3-fingerprint`` also decode banners with these encodings.
+``telnetlib3-fingerprint`` decodes and translates banners with these
+encodings, including PETSCII colors.
+
+SyncTERM Font Detection
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a server sends a SyncTERM/CTerm font selection sequence
+(``CSI Ps1 ; Ps2 SP D``), both ``telnetlib3-client`` and
+``telnetlib3-fingerprint`` automatically switch the session encoding
+to match the font (e.g. font 36 = ATASCII, 32-35 = PETSCII, 0 = CP437).
+An explicit ``--encoding`` flag takes precedence over font detection.
 
 Line Endings
 ~~~~~~~~~~~~
@@ -255,6 +273,44 @@ as-is -- it does **not** convert ``\n`` to ``\r\n``::
 
 For maximum compatibility with MUD clients, legacy terminals, and standard
 telnet implementations, always use ``\r\n`` with ``write()``.
+
+Raw Mode and Line Mode
+~~~~~~~~~~~~~~~~~~~~~~
+
+``telnetlib3-client`` defaults to **raw terminal mode** -- the local
+terminal is set to raw (no line buffering, no local echo, no signal
+processing), and each keystroke is sent to the server immediately.  This
+is the correct mode for most BBS and MUD servers that handle their own
+echo and line editing.
+
+Use ``--line-mode`` to switch to line-buffered input with local echo,
+which is appropriate for simple command-line services that expect the
+client to perform local line editing::
+
+    # Default: raw mode (correct for most servers)
+    telnetlib3-client bbs.example.com
+
+    # Line mode: local echo and line buffering
+    telnetlib3-client --line-mode simple-service.example.com
+
+Similarly, ``telnetlib3-server --pty-exec`` defaults to raw PTY mode
+(disabling PTY echo), which is correct for programs that handle their own
+terminal I/O (curses, blessed, etc.).  Use ``--line-mode`` for programs
+that expect cooked/canonical PTY mode::
+
+    # Default: raw PTY (correct for curses programs)
+    telnetlib3-server --pty-exec /bin/bash -- --login
+
+    # Line mode: cooked PTY with echo (for simple programs like bc)
+    telnetlib3-server --pty-exec /bin/bc --line-mode
+
+Debugging
+~~~~~~~~~
+
+Use ``--loglevel=trace`` to see hexdump-style output of all bytes sent
+and received on the wire::
+
+    telnetlib3-client --loglevel=trace --logfile=debug.log bbs.example.com
 
 server_binary.py
 ~~~~~~~~~~~~~~~~

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -33,6 +33,27 @@ History
     advertised by servers — ``iso-8859-02`` → ``iso-8859-2``,
     ``cp-1250`` → ``cp1250``, etc. — so they resolve in Python's codec
     registry instead of being silently rejected.
+  * bugfix: ATASCII codec now maps bytes 0x0D and 0x0A to CR and LF instead
+    of graphics characters, matching PETSCII and Atari ST behaviour.  This
+    fixes garbled output (``🮂`` and ``◣`` in place of line breaks) when
+    connecting to Atari BBS systems over telnet.
+  * new: SyncTERM/CTerm font selection sequence detection
+    (``CSI Ps1 ; Ps2 SP D``).  Both ``telnetlib3-fingerprint`` and
+    ``telnetlib3-client`` now detect font switching and auto-switch
+    ``environ_encoding`` to the matching codec (e.g. font 36 = ATASCII,
+    32-35 = PETSCII, 0 = CP437, 40 = Topaz/CP437).
+  * enhancement: ``telnetlib3-fingerprint`` detects "More: (Y)es, (N)o,
+    (C)ontinuous?" pagination prompts and answers "C" (Continuous) to collect
+    the full banner without stalling.
+  * new: ``--raw-mode`` CLI option for ``telnetlib3-client`` — forces raw
+    terminal mode (no line buffering, no local echo) regardless of server
+    ECHO negotiation.  Auto-enabled for ATASCII and PETSCII encodings so
+    retro BBS connections work character-at-a-time like ``stty raw -echo``.
+  * new: PETSCII color translation — inline C64 color control codes are
+    translated to ANSI 24-bit RGB using the VIC-II palette (Pepto's colodore
+    reference).  ``telnetlib3-client --encoding=petscii`` displays colors;
+    ``telnetlib3-fingerprint`` saves colored banners.  RVS ON/OFF are
+    translated to ANSI reverse video.  New palette ``--colormatch=c64``.
   * removed: unused ``get_next_ascii()`` from :mod:`telnetlib3.server_shell`.
 
 2.4.0

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,53 +1,25 @@
 History
 =======
 2.5.0
-  * change: ``telnetlib3-client`` now defaults to raw terminal mode (no line
-    buffering, no local echo), which is correct for most BBS and MUD servers.
-    Use ``--line-mode`` to restore line-buffered local-echo behavior.
-  * change: ``telnetlib3-server --pty-exec`` now defaults to raw PTY mode.
-    Use ``--line-mode`` to restore cooked PTY mode with echo.  The previous
-    ``--pty-raw`` flag is accepted as a silent no-op for compatibility.
+  * change: ``telnetlib3-client`` now defaults to raw terminal mode (no line buffering, no local
+    echo), which is correct for most servers.  Use ``--line-mode`` to restore line-buffered
+    local-echo behavior.
+  * change: ``telnetlib3-server --pty-exec`` now defaults to raw PTY mode.  Use ``--line-mode`` to
+    restore cooked PTY mode with echo.
   * change: ``connect_minwait`` default reduced to 0 across
-    :class:`~telnetlib3.client_base.BaseClient`,
-    :func:`~telnetlib3.client.open_connection`, and ``telnetlib3-client``.
-    Negotiation continues asynchronously.  Use ``--connect-minwait`` to
-    restore a delay if needed.
-  * change: default ``--colormatch`` palette changed from EGA to VGA.
-  * new: :class:`~telnetlib3.color_filter.PetsciiColorFilter` -- C64 color
-    codes are translated to ANSI 24-bit RGB using the VIC-II palette
-    (Pepto's colodore reference); cursor movement, HOME, CLR, and DEL are
-    translated to ANSI sequences; RVS ON/OFF to ANSI reverse video.
-    New palette ``--colormatch=c64``.
-  * new: :class:`~telnetlib3.color_filter.AtasciiControlFilter` -- decoded
-    ATASCII control character glyphs (cursor movement, backspace, clear
-    screen, tab) are translated to ANSI terminal sequences.
-  * new: :class:`~telnetlib3.client_shell.InputFilter` -- keyboard input
-    translation for retro encodings.  Arrow keys, backspace, delete, and
-    enter are mapped to the correct raw bytes for ATASCII and PETSCII.
-  * new: SyncTERM/CTerm font selection sequence detection
-    (``CSI Ps1 ; Ps2 SP D``).  Both ``telnetlib3-fingerprint`` and
-    ``telnetlib3-client`` detect font switching and auto-switch encoding
-    to the matching codec (e.g. font 36 = ATASCII, 32-35 = PETSCII,
-    0 = CP437).  Explicit ``--encoding`` takes precedence.
-  * new: :data:`~telnetlib3.accessories.TRACE` log level (5, below
-    ``DEBUG``) with :func:`~telnetlib3.accessories.hexdump` style output
-    for all sent and received bytes.  Use ``--loglevel=trace``.
-  * enhancement: ``telnetlib3-fingerprint`` responds to DSR (``ESC[6n``)
-    with position-aware CPR replies using a virtual cursor, so servers that
-    probe for ANSI capability or measure character width no longer
-    disconnect or reject the scanner.
-  * enhancement: ``telnetlib3-fingerprint`` answers up to 5 sequential
-    prompts (e.g. color, charset menu, pagination) instead of only one.
-  * enhancement: ``telnetlib3-fingerprint`` answers Mystic BBS "Press
-    [.ESC.] twice" botcheck prompts inline during banner collection.
-  * enhancement: ``telnetlib3-fingerprint`` strips ANSI escape sequences
-    before prompt pattern matching, fixing detection through color codes.
-  * enhancement: ``telnetlib3-fingerprint`` detects "HIT RETURN", "PRESS
-    ENTER", "More: (Y)es (N)o (C)ontinuous", "Press the BACKSPACE key",
-    and "press DEL/backspace" prompts and responds automatically.
-  * enhancement: ``telnetlib3-fingerprint`` banner formatting uses
-    ``surrogateescape`` error handler, preserving raw high bytes (e.g. CP437
-    art) as surrogates instead of replacing them with U+FFFD.
+    :class:`~telnetlib3.client_base.BaseClient`, :func:`~telnetlib3.client.open_connection`, and
+    ``telnetlib3-client``.  Negotiation continues asynchronously.  Use ``--connect-minwait`` to
+    restore a delay if needed, or, use :meth:`~telnetlib3.stream_writer.TelnetWriter.wait_for` in
+    server or client shells to await a specific negotiation state.
+  * new: Color, keyboard input translation and ``--encoding`` support for ATASCII (ATARI ASCII) and
+    PETSCII (Commodore ASCII).
+  * new: SyncTERM/CTerm font selection sequence detection (``CSI Ps1 ; Ps2 SP D``).  Both
+    ``telnetlib3-fingerprint`` and ``telnetlib3-client`` detect font switching and auto-switch
+    encoding to the matching codec (e.g. font 36 = ATASCII, 32-35 = PETSCII, 0 = CP437).  Explicit
+    ``--encoding`` takes precedence.
+  * new: :data:`~telnetlib3.accessories.TRACE` log level (5, below ``DEBUG``) with
+    :func:`~telnetlib3.accessories.hexdump` style output for all sent and received bytes.  Use
+    ``--loglevel=trace``.
   * bugfix: :func:`~telnetlib3.guard_shells.robot_check` now uses a narrow
     character (space) instead of a wide Unicode character, allowing retro
     terminal emulators to pass.
@@ -66,7 +38,12 @@ History
   * bugfix: :meth:`~telnetlib3.client.TelnetClient.send_charset` normalises
     non-standard encoding names (``iso-8859-02`` to ``iso-8859-2``,
     ``cp-1250`` to ``cp1250``, etc.).
-  * removed: ``get_next_ascii()`` from :mod:`telnetlib3.server_shell`.
+  * enhancement: ``telnetlib3-fingerprint`` responds more like a terminal and to more
+    y/n prompts about colors, encoding, etc. to collect more banners for https://bbs.modem.xyz/
+    project.
+  * enhancement: ``telnetlib3-fingerprint`` banner formatting uses
+    ``surrogateescape`` error handler, preserving raw high bytes (e.g. CP437
+    art) as surrogates instead of replacing them with U+FFFD.
 
 2.4.0
   * new: :mod:`telnetlib3.color_filter` module — translates 16-color ANSI SGR

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -49,11 +49,18 @@ History
     terminal mode (no line buffering, no local echo) regardless of server
     ECHO negotiation.  Auto-enabled for ATASCII and PETSCII encodings so
     retro BBS connections work character-at-a-time like ``stty raw -echo``.
-  * new: PETSCII color translation — inline C64 color control codes are
+  * new: PETSCII control code translation — inline C64 color codes are
     translated to ANSI 24-bit RGB using the VIC-II palette (Pepto's colodore
-    reference).  ``telnetlib3-client --encoding=petscii`` displays colors;
-    ``telnetlib3-fingerprint`` saves colored banners.  RVS ON/OFF are
-    translated to ANSI reverse video.  New palette ``--colormatch=c64``.
+    reference); cursor movement (up/down/left/right), HOME, CLR, and DEL
+    are translated to ANSI cursor sequences; RVS ON/OFF to ANSI reverse
+    video.  ``telnetlib3-client --encoding=petscii`` displays colors and
+    cursor art; ``telnetlib3-fingerprint`` saves translated banners.
+    New palette ``--colormatch=c64``.
+  * bugfix: PETSCII newline handling — bare CR (0x0D, the PETSCII line
+    terminator) is now normalized to CRLF in raw terminal mode and to LF
+    in ``telnetlib3-fingerprint`` banners.  Previously, bare CR only moved
+    the cursor to column 0 without advancing the row, causing every line
+    to overwrite the previous one on PETSCII BBS connections.
   * removed: unused ``get_next_ascii()`` from :mod:`telnetlib3.server_shell`.
 
 2.4.0

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -17,6 +17,14 @@ History
   * enhancement: default ``--colormatch`` palette changed from EGA to VGA.
   * bugfix: "robot" guard now uses a narrow character (space) instead of a
     wide Unicode character, allowing retro terminal emulators to pass.
+  * enhancement: ``telnetlib3-fingerprint`` detects "HIT RETURN" and "PRESS
+    ENTER" prompts and responds automatically during banner collection.
+  * bugfix: ATASCII codec now normalizes CR and CRLF to the native ATASCII
+    EOL (0x9B) during encoding, so the Return key works correctly with
+    ``telnetlib3-client --encoding=atascii``.
+  * bugfix: ``telnetlib3-fingerprint`` re-encodes prompt responses for retro
+    encodings (ATASCII) so that servers receive the correct EOL byte instead
+    of ASCII CR/LF.
   * removed: unused ``get_next_ascii()`` from :mod:`telnetlib3.server_shell`.
 
 2.4.0

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -25,6 +25,14 @@ History
   * bugfix: ``telnetlib3-fingerprint`` re-encodes prompt responses for retro
     encodings (ATASCII) so that servers receive the correct EOL byte instead
     of ASCII CR/LF.
+  * bugfix: ``telnetlib3-fingerprint`` no longer crashes with
+    ``LookupError: unknown encoding`` when the server negotiates a charset
+    that Python cannot look up (e.g. ``atascii`` without the codec registered).
+    Banner formatting now falls back to ``latin-1``.
+  * bugfix: CHARSET negotiation now normalises non-standard encoding names
+    advertised by servers — ``iso-8859-02`` → ``iso-8859-2``,
+    ``cp-1250`` → ``cp1250``, etc. — so they resolve in Python's codec
+    registry instead of being silently rejected.
   * removed: unused ``get_next_ascii()`` from :mod:`telnetlib3.server_shell`.
 
 2.4.0

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,7 +1,23 @@
 History
 =======
 2.5.0
-  * bugfix: "robot" guard now allows retro computer users.
+  * change: ``connect_minwait`` default reduced from 1.0s to 0 across
+    ``BaseClient``, ``open_connection()``, and the ``telnetlib3-client`` CLI.
+    The shell now starts immediately after connection; negotiation continues
+    asynchronously.  Use ``--connect-minwait`` to restore a delay if needed.
+  * enhancement: ``telnetlib3-fingerprint`` responds to DSR (``ESC[6n``)
+    during banner collection with a CPR reply, so servers that probe for
+    ANSI capability no longer disconnect prematurely.
+  * enhancement: ``telnetlib3-fingerprint`` answers up to 3 sequential
+    prompts (e.g. color, charset menu) instead of only one.
+  * enhancement: ``telnetlib3-fingerprint`` answers Mystic BBS "Press
+    [.ESC.] twice" botcheck prompts.
+  * enhancement: ``telnetlib3-fingerprint`` strips ANSI escape sequences
+    before prompt pattern matching, fixing detection through color codes.
+  * enhancement: default ``--colormatch`` palette changed from EGA to VGA.
+  * bugfix: "robot" guard now uses a narrow character (space) instead of a
+    wide Unicode character, allowing retro terminal emulators to pass.
+  * removed: unused ``get_next_ascii()`` from :mod:`telnetlib3.server_shell`.
 
 2.4.0
   * new: :mod:`telnetlib3.color_filter` module — translates 16-color ANSI SGR

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,7 @@
 History
 =======
+2.5.0
+  * bugfix: "robot" guard now allows retro computer users.
 
 2.4.0
   * new: :mod:`telnetlib3.color_filter` module — translates 16-color ANSI SGR
@@ -28,7 +30,13 @@ History
     auto-answers yes/no, color, UTF-8 menu, ``who``, and ``help`` prompts.
   * enhancement: ``--banner-max-bytes`` option for ``telnetlib3-fingerprint``;
     default raised from 1024 to 65536.
-  * enhancement: new ``--encoding=petscii`` and ``--encoding=atarist``
+  * new: ATASCII (Atari 8-bit) codec -- ``--encoding=atascii`` for connecting
+    to Atari BBS systems.  Maps all 256 byte values to Unicode including
+    graphics characters, card suits, and the inverse-video range (0x80-0xFF).
+    ATASCII EOL (0x9B) maps to newline.  Aliases: ``atari8bit``, ``atari_8bit``.
+  * enhancement: ``--encoding=atascii``, ``--encoding=petscii``, and
+    ``--encoding=atarist`` now auto-enable ``--force-binary`` for both client
+    and server, since these encodings use bytes 0x80-0xFF for standard glyphs.
   * bugfix: rare LINEMODE ACK loop with misbehaving servers that re-send
     unchanged MODE without ACK.
   * bugfix: unknown IAC commands no longer raise ``ValueError``; treated as

--- a/telnetlib3/client.py
+++ b/telnetlib3/client.py
@@ -532,7 +532,7 @@ async def open_connection(  # pylint: disable=too-many-locals
     return protocol.reader, protocol.writer
 
 
-async def run_client() -> None:  # pylint: disable=too-many-locals,too-many-statements
+async def run_client() -> None:  # pylint: disable=too-many-locals,too-many-statements,too-complex
     """Command-line 'telnetlib3-client' entry point, via setuptools."""
     args = _transform_args(_get_argument_parser().parse_args())
     config_msg = f"Client configuration: {accessories.repr_mapping(args)}"

--- a/telnetlib3/client.py
+++ b/telnetlib3/client.py
@@ -373,7 +373,7 @@ async def open_connection(  # pylint: disable=too-many-locals
     tspeed: Tuple[int, int] = (38400, 38400),
     xdisploc: str = "",
     shell: Optional[ShellCallback] = None,
-    connect_minwait: float = 2.0,
+    connect_minwait: float = 0,
     connect_maxwait: float = 3.0,
     connect_timeout: Optional[float] = None,
     waiter_closed: Optional[asyncio.Future[None]] = None,
@@ -614,7 +614,7 @@ def _get_argument_parser() -> argparse.ArgumentParser:
 
     parser.add_argument("--force-binary", action="store_true", help="force encoding", default=True)
     parser.add_argument(
-        "--connect-minwait", default=1.0, type=float, help="shell delay for negotiation"
+        "--connect-minwait", default=0, type=float, help="shell delay for negotiation"
     )
     parser.add_argument(
         "--connect-maxwait", default=4.0, type=float, help="timeout for pending negotiation"
@@ -940,7 +940,7 @@ async def run_fingerprint_client() -> None:
             shell=shell,
             encoding=False,
             term=ttype,
-            connect_minwait=2.0,
+            connect_minwait=0,
             connect_maxwait=4.0,
             connect_timeout=args.connect_timeout,
             waiter_closed=waiter_closed,

--- a/telnetlib3/client.py
+++ b/telnetlib3/client.py
@@ -646,7 +646,7 @@ def _get_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--colormatch",
-        default="ega",
+        default="vga",
         metavar="PALETTE",
         help=(
             "translate basic 16-color ANSI codes to exact 24-bit RGB values"
@@ -716,6 +716,13 @@ def _parse_background_color(value: str) -> Tuple[int, int, int]:
 
 
 def _transform_args(args: argparse.Namespace) -> Dict[str, Any]:
+    # Auto-enable force_binary for retro BBS encodings that use high-bit bytes.
+    from .encodings import FORCE_BINARY_ENCODINGS  # pylint: disable=import-outside-toplevel
+
+    force_binary = args.force_binary
+    if args.encoding.lower().replace('-', '_') in FORCE_BINARY_ENCODINGS:
+        force_binary = True
+
     return {
         "host": args.host,
         "port": args.port,
@@ -726,7 +733,7 @@ def _transform_args(args: argparse.Namespace) -> Dict[str, Any]:
         "tspeed": (args.speed, args.speed),
         "shell": accessories.function_lookup(args.shell),
         "term": args.term,
-        "force_binary": args.force_binary,
+        "force_binary": force_binary,
         "encoding_errors": args.encoding_errors,
         "connect_minwait": args.connect_minwait,
         "connect_timeout": args.connect_timeout,

--- a/telnetlib3/client.py
+++ b/telnetlib3/client.py
@@ -588,7 +588,7 @@ async def run_client() -> None:
         is_atascii = encoding_name.lower() in ("atascii", "atari8bit", "atari_8bit")
         if colormatch == "petscii":
             colormatch = "c64"
-        if is_petscii and colormatch == "ega":
+        if is_petscii and colormatch != "c64":
             colormatch = "c64"
 
         if colormatch not in PALETTES:
@@ -699,11 +699,12 @@ def _get_argument_parser() -> argparse.ArgumentParser:
 
     parser.add_argument("--force-binary", action="store_true", help="force encoding", default=True)
     parser.add_argument(
-        "--raw-mode",
+        "--line-mode",
         action="store_true",
         default=False,
-        help="force raw terminal mode (no line buffering, no local echo). "
-        "Auto-enabled for atascii and petscii encodings.",
+        help="use line-buffered input with local echo instead of raw terminal "
+        "mode.  By default the client uses raw mode (no line buffering, no "
+        "local echo) which is correct for most BBS and MUD servers.",
     )
     parser.add_argument(
         "--connect-minwait", default=0, type=float, help="shell delay for negotiation"
@@ -812,7 +813,7 @@ def _transform_args(args: argparse.Namespace) -> Dict[str, Any]:
     from .encodings import FORCE_BINARY_ENCODINGS  # pylint: disable=import-outside-toplevel
 
     force_binary = args.force_binary
-    raw_mode = args.raw_mode
+    raw_mode = not args.line_mode
     if args.encoding.lower().replace('-', '_') in FORCE_BINARY_ENCODINGS:
         force_binary = True
         raw_mode = True

--- a/telnetlib3/client_base.py
+++ b/telnetlib3/client_base.py
@@ -15,8 +15,8 @@ from typing import Any, Type, Union, Callable, Optional, cast
 
 # local
 from ._types import ShellCallback
-from .accessories import TRACE, hexdump
 from .telopt import DO, WILL, theNULL, name_commands
+from .accessories import TRACE, hexdump
 from .stream_reader import TelnetReader, TelnetReaderUnicode
 from .stream_writer import TelnetWriter, TelnetWriterUnicode
 
@@ -240,7 +240,8 @@ class BaseClient(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                     pass
 
     def _detect_syncterm_font(self, data: bytes) -> None:
-        """Scan *data* for SyncTERM font selection and switch encoding.
+        """
+        Scan *data* for SyncTERM font selection and switch encoding.
 
         When :attr:`_encoding_explicit` is set on the writer (indicating
         the user passed ``--encoding``), the font switch is logged but
@@ -248,9 +249,10 @@ class BaseClient(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         """
         if self.writer is None:
             return
+        # local
         from .server_fingerprinting import (  # pylint: disable=import-outside-toplevel
-            detect_syncterm_font,
             _SYNCTERM_BINARY_ENCODINGS,
+            detect_syncterm_font,
         )
         encoding = detect_syncterm_font(data)
         if encoding is not None:

--- a/telnetlib3/client_base.py
+++ b/telnetlib3/client_base.py
@@ -15,6 +15,7 @@ from typing import Any, Type, Union, Callable, Optional, cast
 
 # local
 from ._types import ShellCallback
+from .accessories import TRACE, hexdump
 from .telopt import DO, WILL, theNULL, name_commands
 from .stream_reader import TelnetReader, TelnetReaderUnicode
 from .stream_writer import TelnetWriter, TelnetWriterUnicode
@@ -44,7 +45,7 @@ class BaseClient(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         encoding: Union[str, bool] = "utf8",
         encoding_errors: str = "strict",
         force_binary: bool = False,
-        connect_minwait: float = 1.0,
+        connect_minwait: float = 0,
         connect_maxwait: float = 4.0,
         limit: Optional[int] = None,
         waiter_closed: Optional[asyncio.Future[None]] = None,
@@ -212,6 +213,8 @@ class BaseClient(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         Buffer incoming data and schedule async processing to keep the event loop responsive. Apply
         read-side backpressure using transport.pause_reading()/resume_reading().
         """
+        if self.log.isEnabledFor(TRACE):
+            self.log.log(TRACE, "recv %d bytes\n%s", len(data), hexdump(data, prefix="<<  "))
         self._last_received = datetime.datetime.now()
 
         # Enqueue and account for buffered size

--- a/telnetlib3/client_shell.py
+++ b/telnetlib3/client_shell.py
@@ -66,7 +66,7 @@ _INPUT_SEQ_XLAT: Dict[str, Dict[bytes, bytes]] = {
 }
 
 
-class InputFilter:
+class InputFilter:  # pylint: disable=too-few-public-methods
     """
     Translate terminal escape sequences and single bytes to retro encoding bytes.
 
@@ -82,6 +82,7 @@ class InputFilter:
     def __init__(
         self, seq_xlat: Dict[bytes, bytes], byte_xlat: Dict[int, int]
     ) -> None:
+        """Initialize input filter with sequence and byte translation tables."""
         self._byte_xlat = byte_xlat
         # Sort sequences longest-first so \x1b[3~ matches before \x1b[3
         self._seq_sorted: Tuple[Tuple[bytes, bytes], ...] = tuple(
@@ -97,9 +98,9 @@ class InputFilter:
         """
         Process input bytes, returning raw bytes to send to the remote host.
 
-        Escape sequences are matched against the configured table and replaced.
-        Partial sequences are buffered until the next call.  Single bytes are
-        translated via the byte translation table.
+        Escape sequences are matched against the configured table and replaced. Partial sequences
+        are buffered until the next call.  Single bytes are translated via the byte translation
+        table.
 
         :param data: Raw bytes from terminal stdin.
         :returns: Translated bytes ready to send to the remote BBS.
@@ -381,7 +382,7 @@ else:
                         if _inf is not None:
                             translated = _inf.feed(inp)
                             if translated:
-                                telnet_writer._write(translated)
+                                telnet_writer._write(translated)  # pylint: disable=protected-access
                         else:
                             telnet_writer.write(inp.decode())
                         stdin_task = accessories.make_reader_task(stdin)

--- a/telnetlib3/color_filter.py
+++ b/telnetlib3/color_filter.py
@@ -503,24 +503,25 @@ _PETSCII_CTRL_RE = re.compile(
 
 
 class PetsciiColorFilter:
-    """
+    r"""
     Translate PETSCII control codes to ANSI sequences.
 
     PETSCII uses single-byte control codes embedded in the text stream for
     color changes, cursor movement, and screen control.  This filter
     translates them to ANSI equivalents:
 
-    - **Colors**: 16 VIC-II palette colors → ``\\x1b[38;2;R;G;Bm`` (24-bit RGB)
-    - **Reverse video**: RVS ON/OFF → ``\\x1b[7m`` / ``\\x1b[27m``
-    - **Cursor**: up/down/left/right → ``\\x1b[A/B/C/D``
-    - **Screen**: HOME → ``\\x1b[H``, CLR → ``\\x1b[2J``
-    - **DEL**: destructive backspace → ``\\x08\\x1b[P``
+    - **Colors**: 16 VIC-II palette colors → ``\x1b[38;2;R;G;Bm`` (24-bit RGB)
+    - **Reverse video**: RVS ON/OFF → ``\x1b[7m`` / ``\x1b[27m``
+    - **Cursor**: up/down/left/right → ``\x1b[A/B/C/D``
+    - **Screen**: HOME → ``\x1b[H``, CLR → ``\x1b[2J``
+    - **DEL**: destructive backspace → ``\x08\x1b[P``
 
     :param config: Color configuration (uses ``brightness`` and ``contrast``
         for palette adjustment; ``palette_name`` is ignored — always C64).
     """
 
     def __init__(self, config: Optional[ColorConfig] = None) -> None:
+        """Initialize PETSCII filter with optional color configuration."""
         palette = PALETTES["c64"]
         if config is not None:
             brightness = config.brightness
@@ -541,9 +542,8 @@ class PetsciiColorFilter:
         """
         Replace PETSCII control codes with ANSI sequences.
 
-        PETSCII control characters (colors, cursor, screen) are replaced
-        with their ANSI equivalents.  All other characters pass through
-        unchanged.
+        PETSCII control characters (colors, cursor, screen) are replaced with their ANSI
+        equivalents.  All other characters pass through unchanged.
 
         :param text: Decoded PETSCII text (Unicode string).
         :returns: Text with PETSCII controls translated to ANSI.
@@ -597,17 +597,17 @@ _ATASCII_CTRL_RE = re.compile(
 
 
 class AtasciiControlFilter:
-    """
+    r"""
     Translate decoded ATASCII control character glyphs to ANSI sequences.
 
     The ``atascii`` codec decodes ATASCII control bytes into Unicode glyphs
     (e.g. byte 0x7E → U+25C0 ◀).  This filter replaces those glyphs with
     the ANSI terminal sequences that produce the intended effect:
 
-    - **Backspace/delete**: ◀ → ``\\x08\\x1b[P`` (destructive backspace)
-    - **Tab**: ▶ → ``\\t``
-    - **Clear screen**: ↰ → ``\\x1b[2J\\x1b[H``
-    - **Cursor movement**: ↑↓←→ → ``\\x1b[A/B/D/C``
+    - **Backspace/delete**: ◀ → ``\x08\x1b[P`` (destructive backspace)
+    - **Tab**: ▶ → ``\t``
+    - **Clear screen**: ↰ → ``\x1b[2J\x1b[H``
+    - **Cursor movement**: ↑↓←→ → ``\x1b[A/B/D/C``
     """
 
     def filter(self, text: str) -> str:

--- a/telnetlib3/encodings/__init__.py
+++ b/telnetlib3/encodings/__init__.py
@@ -1,9 +1,10 @@
 """
 Custom BBS/retro-computing codecs for telnetlib3.
 
-Registers petscii and atarist codecs with Python's codecs module on import.
-These encodings are then available for use with ``bytes.decode()`` and the
-``--encoding`` CLI flag of ``telnetlib3-fingerprint``.
+Registers atascii, petscii, and atarist codecs with Python's codecs module
+on import.  These encodings are then available for use with
+``bytes.decode()`` and the ``--encoding`` CLI flag of
+``telnetlib3-fingerprint``.
 """
 
 # std imports
@@ -44,5 +45,13 @@ def _search_function(encoding):
 
     return info
 
+
+#: Encoding names (and aliases) that require BINARY mode for high-bit bytes.
+#: Used by CLI entry points to auto-enable ``--force-binary``.
+FORCE_BINARY_ENCODINGS = frozenset({
+    'atascii', 'atari8bit', 'atari_8bit',
+    'petscii', 'cbm', 'commodore', 'c64', 'c128',
+    'atarist', 'atari',
+})
 
 codecs.register(_search_function)

--- a/telnetlib3/encodings/atascii.py
+++ b/telnetlib3/encodings/atascii.py
@@ -1,0 +1,418 @@
+"""
+ATASCII (Atari 8-bit) encoding.
+
+ATASCII is the character encoding used by Atari 8-bit computers (400, 800,
+XL, XE series).  It shares the printable ASCII range 0x20-0x7A with standard
+ASCII, but replaces control codes 0x00-0x1F with graphics characters and uses
+0x80-0xFF as inverse-video variants.
+
+Mapping sources:
+- https://www.kreativekorp.com/charset/map/atascii/
+- https://github.com/JSJvR/atari-8-bit-utils
+
+The inverse-video range (0x80-0xFF) maps to the same Unicode characters as
+the corresponding normal byte (byte & 0x7F), except where a distinct glyph
+exists (e.g. complementary block elements).  This makes encoding lossy for
+inverse bytes, which is the same trade-off as the PETSCII codec.
+
+Notable: 0x9B is the ATASCII end-of-line character (mapped to U+000A LF).
+"""
+
+# std imports
+import codecs
+from typing import Dict, Tuple, Union
+
+# Decoding Table -- ATASCII, 256 entries.
+#
+# 0x00-0x1F : graphics characters (heart, box drawing, triangles, etc.)
+# 0x20-0x5F : standard ASCII (space, digits, uppercase, punctuation)
+# 0x60      : diamond suit
+# 0x61-0x7A : lowercase a-z
+# 0x7B-0x7F : spade suit, pipe, clear-screen, backspace, tab glyphs
+# 0x80-0xFF : inverse video (mostly same glyphs as 0x00-0x7F)
+
+DECODING_TABLE = (
+    # 0x00-0x1F: Graphics characters
+    '\u2665'    # 0x00 BLACK HEART SUIT
+    '\u251c'    # 0x01 BOX DRAWINGS LIGHT VERTICAL AND RIGHT
+    '\u23b9'    # 0x02 RIGHT VERTICAL BOX LINE
+    '\u2518'    # 0x03 BOX DRAWINGS LIGHT UP AND LEFT
+    '\u2524'    # 0x04 BOX DRAWINGS LIGHT VERTICAL AND LEFT
+    '\u2510'    # 0x05 BOX DRAWINGS LIGHT DOWN AND LEFT
+    '\u2571'    # 0x06 BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT
+    '\u2572'    # 0x07 BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT
+    '\u25e2'    # 0x08 BLACK LOWER RIGHT TRIANGLE
+    '\u2597'    # 0x09 QUADRANT LOWER RIGHT
+    '\u25e3'    # 0x0A BLACK LOWER LEFT TRIANGLE
+    '\u259d'    # 0x0B QUADRANT UPPER RIGHT
+    '\u2598'    # 0x0C QUADRANT UPPER LEFT
+    '\U0001fb82'  # 0x0D UPPER ONE QUARTER BLOCK
+    '\u2582'    # 0x0E LOWER ONE QUARTER BLOCK
+    '\u2596'    # 0x0F QUADRANT LOWER LEFT
+    '\u2663'    # 0x10 BLACK CLUB SUIT
+    '\u250c'    # 0x11 BOX DRAWINGS LIGHT DOWN AND RIGHT
+    '\u2500'    # 0x12 BOX DRAWINGS LIGHT HORIZONTAL
+    '\u253c'    # 0x13 BOX DRAWINGS LIGHT VERTICAL AND HORIZONTAL
+    '\u25cf'    # 0x14 BLACK CIRCLE
+    '\u2584'    # 0x15 LOWER HALF BLOCK
+    '\u258e'    # 0x16 LEFT ONE QUARTER BLOCK
+    '\u252c'    # 0x17 BOX DRAWINGS LIGHT DOWN AND HORIZONTAL
+    '\u2534'    # 0x18 BOX DRAWINGS LIGHT UP AND HORIZONTAL
+    '\u258c'    # 0x19 LEFT HALF BLOCK
+    '\u2514'    # 0x1A BOX DRAWINGS LIGHT UP AND RIGHT
+    '\u241b'    # 0x1B SYMBOL FOR ESCAPE
+    '\u2191'    # 0x1C UPWARDS ARROW (cursor up)
+    '\u2193'    # 0x1D DOWNWARDS ARROW (cursor down)
+    '\u2190'    # 0x1E LEFTWARDS ARROW (cursor left)
+    '\u2192'    # 0x1F RIGHTWARDS ARROW (cursor right)
+    # 0x20-0x5F: Standard ASCII
+    ' '         # 0x20 SPACE
+    '!'         # 0x21
+    '"'         # 0x22
+    '#'         # 0x23
+    '$'         # 0x24
+    '%'         # 0x25
+    '&'         # 0x26
+    "'"         # 0x27
+    '('         # 0x28
+    ')'         # 0x29
+    '*'         # 0x2A
+    '+'         # 0x2B
+    ','         # 0x2C
+    '-'         # 0x2D
+    '.'         # 0x2E
+    '/'         # 0x2F
+    '0'         # 0x30
+    '1'         # 0x31
+    '2'         # 0x32
+    '3'         # 0x33
+    '4'         # 0x34
+    '5'         # 0x35
+    '6'         # 0x36
+    '7'         # 0x37
+    '8'         # 0x38
+    '9'         # 0x39
+    ':'         # 0x3A
+    ';'         # 0x3B
+    '<'         # 0x3C
+    '='         # 0x3D
+    '>'         # 0x3E
+    '?'         # 0x3F
+    '@'         # 0x40
+    'A'         # 0x41
+    'B'         # 0x42
+    'C'         # 0x43
+    'D'         # 0x44
+    'E'         # 0x45
+    'F'         # 0x46
+    'G'         # 0x47
+    'H'         # 0x48
+    'I'         # 0x49
+    'J'         # 0x4A
+    'K'         # 0x4B
+    'L'         # 0x4C
+    'M'         # 0x4D
+    'N'         # 0x4E
+    'O'         # 0x4F
+    'P'         # 0x50
+    'Q'         # 0x51
+    'R'         # 0x52
+    'S'         # 0x53
+    'T'         # 0x54
+    'U'         # 0x55
+    'V'         # 0x56
+    'W'         # 0x57
+    'X'         # 0x58
+    'Y'         # 0x59
+    'Z'         # 0x5A
+    '['         # 0x5B
+    '\\'        # 0x5C
+    ']'         # 0x5D
+    '^'         # 0x5E
+    '_'         # 0x5F
+    # 0x60-0x7F: Lowercase + special glyphs
+    '\u2666'    # 0x60 BLACK DIAMOND SUIT
+    'a'         # 0x61
+    'b'         # 0x62
+    'c'         # 0x63
+    'd'         # 0x64
+    'e'         # 0x65
+    'f'         # 0x66
+    'g'         # 0x67
+    'h'         # 0x68
+    'i'         # 0x69
+    'j'         # 0x6A
+    'k'         # 0x6B
+    'l'         # 0x6C
+    'm'         # 0x6D
+    'n'         # 0x6E
+    'o'         # 0x6F
+    'p'         # 0x70
+    'q'         # 0x71
+    'r'         # 0x72
+    's'         # 0x73
+    't'         # 0x74
+    'u'         # 0x75
+    'v'         # 0x76
+    'w'         # 0x77
+    'x'         # 0x78
+    'y'         # 0x79
+    'z'         # 0x7A
+    '\u2660'    # 0x7B BLACK SPADE SUIT
+    '|'         # 0x7C VERTICAL LINE
+    '\u21b0'    # 0x7D UPWARDS ARROW WITH TIP LEFTWARDS (clear screen)
+    '\u25c0'    # 0x7E BLACK LEFT-POINTING TRIANGLE (backspace)
+    '\u25b6'    # 0x7F BLACK RIGHT-POINTING TRIANGLE (tab)
+    # 0x80-0xFF: Inverse video range
+    # Bytes with distinct glyphs get their own Unicode mapping;
+    # the rest share the same character as (byte & 0x7F).
+    '\u2665'    # 0x80 = inverse of 0x00 (heart)
+    '\u251c'    # 0x81 = inverse of 0x01
+    '\u258a'    # 0x82 LEFT THREE QUARTERS BLOCK (distinct)
+    '\u2518'    # 0x83 = inverse of 0x03
+    '\u2524'    # 0x84 = inverse of 0x04
+    '\u2510'    # 0x85 = inverse of 0x05
+    '\u2571'    # 0x86 = inverse of 0x06
+    '\u2572'    # 0x87 = inverse of 0x07
+    '\u25e4'    # 0x88 BLACK UPPER LEFT TRIANGLE (distinct)
+    '\u259b'    # 0x89 QUADRANT UPPER LEFT AND UPPER RIGHT AND LOWER LEFT (distinct)
+    '\u25e5'    # 0x8A BLACK UPPER RIGHT TRIANGLE (distinct)
+    '\u2599'    # 0x8B QUADRANT UPPER LEFT AND LOWER LEFT AND LOWER RIGHT (distinct)
+    '\u259f'    # 0x8C QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT (distinct)
+    '\u2586'    # 0x8D LOWER THREE QUARTERS BLOCK (distinct)
+    '\U0001fb85'  # 0x8E UPPER THREE QUARTERS BLOCK (distinct)
+    '\u259c'    # 0x8F QUADRANT UPPER LEFT AND UPPER RIGHT AND LOWER RIGHT (distinct)
+    '\u2663'    # 0x90 = inverse of 0x10 (club)
+    '\u250c'    # 0x91 = inverse of 0x11
+    '\u2500'    # 0x92 = inverse of 0x12
+    '\u253c'    # 0x93 = inverse of 0x13
+    '\u25d8'    # 0x94 INVERSE BULLET (distinct)
+    '\u2580'    # 0x95 UPPER HALF BLOCK (distinct)
+    '\U0001fb8a'  # 0x96 RIGHT THREE QUARTERS BLOCK (distinct)
+    '\u252c'    # 0x97 = inverse of 0x17
+    '\u2534'    # 0x98 = inverse of 0x18
+    '\u2590'    # 0x99 RIGHT HALF BLOCK (distinct)
+    '\u2514'    # 0x9A = inverse of 0x1A
+    '\n'        # 0x9B ATASCII END OF LINE
+    '\u2191'    # 0x9C = inverse of 0x1C (up arrow)
+    '\u2193'    # 0x9D = inverse of 0x1D (down arrow)
+    '\u2190'    # 0x9E = inverse of 0x1E (left arrow)
+    '\u2192'    # 0x9F = inverse of 0x1F (right arrow)
+    '\u2588'    # 0xA0 FULL BLOCK (distinct)
+    '!'         # 0xA1 = inverse of 0x21
+    '"'         # 0xA2 = inverse of 0x22
+    '#'         # 0xA3 = inverse of 0x23
+    '$'         # 0xA4 = inverse of 0x24
+    '%'         # 0xA5 = inverse of 0x25
+    '&'         # 0xA6 = inverse of 0x26
+    "'"         # 0xA7 = inverse of 0x27
+    '('         # 0xA8 = inverse of 0x28
+    ')'         # 0xA9 = inverse of 0x29
+    '*'         # 0xAA = inverse of 0x2A
+    '+'         # 0xAB = inverse of 0x2B
+    ','         # 0xAC = inverse of 0x2C
+    '-'         # 0xAD = inverse of 0x2D
+    '.'         # 0xAE = inverse of 0x2E
+    '/'         # 0xAF = inverse of 0x2F
+    '0'         # 0xB0 = inverse of 0x30
+    '1'         # 0xB1 = inverse of 0x31
+    '2'         # 0xB2 = inverse of 0x32
+    '3'         # 0xB3 = inverse of 0x33
+    '4'         # 0xB4 = inverse of 0x34
+    '5'         # 0xB5 = inverse of 0x35
+    '6'         # 0xB6 = inverse of 0x36
+    '7'         # 0xB7 = inverse of 0x37
+    '8'         # 0xB8 = inverse of 0x38
+    '9'         # 0xB9 = inverse of 0x39
+    ':'         # 0xBA = inverse of 0x3A
+    ';'         # 0xBB = inverse of 0x3B
+    '<'         # 0xBC = inverse of 0x3C
+    '='         # 0xBD = inverse of 0x3D
+    '>'         # 0xBE = inverse of 0x3E
+    '?'         # 0xBF = inverse of 0x3F
+    '@'         # 0xC0 = inverse of 0x40
+    'A'         # 0xC1 = inverse of 0x41
+    'B'         # 0xC2 = inverse of 0x42
+    'C'         # 0xC3 = inverse of 0x43
+    'D'         # 0xC4 = inverse of 0x44
+    'E'         # 0xC5 = inverse of 0x45
+    'F'         # 0xC6 = inverse of 0x46
+    'G'         # 0xC7 = inverse of 0x47
+    'H'         # 0xC8 = inverse of 0x48
+    'I'         # 0xC9 = inverse of 0x49
+    'J'         # 0xCA = inverse of 0x4A
+    'K'         # 0xCB = inverse of 0x4B
+    'L'         # 0xCC = inverse of 0x4C
+    'M'         # 0xCD = inverse of 0x4D
+    'N'         # 0xCE = inverse of 0x4E
+    'O'         # 0xCF = inverse of 0x4F
+    'P'         # 0xD0 = inverse of 0x50
+    'Q'         # 0xD1 = inverse of 0x51
+    'R'         # 0xD2 = inverse of 0x52
+    'S'         # 0xD3 = inverse of 0x53
+    'T'         # 0xD4 = inverse of 0x54
+    'U'         # 0xD5 = inverse of 0x55
+    'V'         # 0xD6 = inverse of 0x56
+    'W'         # 0xD7 = inverse of 0x57
+    'X'         # 0xD8 = inverse of 0x58
+    'Y'         # 0xD9 = inverse of 0x59
+    'Z'         # 0xDA = inverse of 0x5A
+    '['         # 0xDB = inverse of 0x5B
+    '\\'        # 0xDC = inverse of 0x5C
+    ']'         # 0xDD = inverse of 0x5D
+    '^'         # 0xDE = inverse of 0x5E
+    '_'         # 0xDF = inverse of 0x5F
+    '\u2666'    # 0xE0 = inverse of 0x60 (diamond)
+    'a'         # 0xE1 = inverse of 0x61
+    'b'         # 0xE2 = inverse of 0x62
+    'c'         # 0xE3 = inverse of 0x63
+    'd'         # 0xE4 = inverse of 0x64
+    'e'         # 0xE5 = inverse of 0x65
+    'f'         # 0xE6 = inverse of 0x66
+    'g'         # 0xE7 = inverse of 0x67
+    'h'         # 0xE8 = inverse of 0x68
+    'i'         # 0xE9 = inverse of 0x69
+    'j'         # 0xEA = inverse of 0x6A
+    'k'         # 0xEB = inverse of 0x6B
+    'l'         # 0xEC = inverse of 0x6C
+    'm'         # 0xED = inverse of 0x6D
+    'n'         # 0xEE = inverse of 0x6E
+    'o'         # 0xEF = inverse of 0x6F
+    'p'         # 0xF0 = inverse of 0x70
+    'q'         # 0xF1 = inverse of 0x71
+    'r'         # 0xF2 = inverse of 0x72
+    's'         # 0xF3 = inverse of 0x73
+    't'         # 0xF4 = inverse of 0x74
+    'u'         # 0xF5 = inverse of 0x75
+    'v'         # 0xF6 = inverse of 0x76
+    'w'         # 0xF7 = inverse of 0x77
+    'x'         # 0xF8 = inverse of 0x78
+    'y'         # 0xF9 = inverse of 0x79
+    'z'         # 0xFA = inverse of 0x7A
+    '\u2660'    # 0xFB = inverse of 0x7B (spade)
+    '|'         # 0xFC = inverse of 0x7C
+    '\u21b0'    # 0xFD = inverse of 0x7D (clear screen)
+    '\u25c0'    # 0xFE = inverse of 0x7E (backspace)
+    '\u25b6'    # 0xFF = inverse of 0x7F (tab)
+)
+
+assert len(DECODING_TABLE) == 256
+
+
+def _normalize_eol(text: str) -> str:
+    r"""
+    Normalize CR and CRLF to LF for ATASCII encoding.
+
+    ATASCII uses byte 0x9B as its end-of-line character, mapped to ``\n`` (U+000A).  Standard CR
+    (U+000D) has no native ATASCII representation (byte 0x0D is a graphics character), so CR and
+    CRLF are both folded to LF before charmap encoding.
+    """
+    return text.replace('\r\n', '\n').replace('\r', '\n')
+
+
+class Codec(codecs.Codec):
+    """ATASCII character map codec."""
+
+    def encode(  # pylint: disable=redefined-builtin
+        self, input: str, errors: str = 'strict'
+    ) -> Tuple[bytes, int]:
+        """Encode input string using ATASCII character map."""
+        input = _normalize_eol(input)
+        return codecs.charmap_encode(input, errors, ENCODING_TABLE)
+
+    def decode(  # pylint: disable=redefined-builtin
+        self, input: bytes, errors: str = 'strict'
+    ) -> Tuple[str, int]:
+        """Decode input bytes using ATASCII character map."""
+        return codecs.charmap_decode(
+            input, errors, DECODING_TABLE  # type: ignore[arg-type]
+        )
+
+
+class IncrementalEncoder(codecs.IncrementalEncoder):
+    """ATASCII incremental encoder with CR/CRLF → LF normalization."""
+
+    def __init__(self, errors: str = 'strict') -> None:
+        """Initialize encoder with pending CR state."""
+        super().__init__(errors)
+        self._pending_cr = False
+
+    def encode(  # pylint: disable=redefined-builtin
+        self, input: str, final: bool = False
+    ) -> bytes:
+        """Encode input string incrementally."""
+        if self._pending_cr:
+            input = '\r' + input
+            self._pending_cr = False
+        if not final and input.endswith('\r'):
+            input = input[:-1]
+            self._pending_cr = True
+        input = _normalize_eol(input)
+        return codecs.charmap_encode(input, self.errors, ENCODING_TABLE)[0]
+
+    def reset(self) -> None:
+        """Reset encoder state."""
+        self._pending_cr = False
+
+    def getstate(self) -> int:
+        """Return encoder state as integer."""
+        return int(self._pending_cr)
+
+    def setstate(self, state: Union[int, str]) -> None:
+        """Restore encoder state from integer."""
+        self._pending_cr = bool(state)
+
+
+class IncrementalDecoder(codecs.IncrementalDecoder):
+    """ATASCII incremental decoder."""
+
+    def decode(  # type: ignore[override]  # pylint: disable=redefined-builtin
+        self, input: bytes, final: bool = False
+    ) -> str:
+        """Decode input bytes incrementally."""
+        return codecs.charmap_decode(
+            input, self.errors, DECODING_TABLE  # type: ignore[arg-type]
+        )[0]
+
+
+class StreamWriter(Codec, codecs.StreamWriter):
+    """ATASCII stream writer."""
+
+
+class StreamReader(Codec, codecs.StreamReader):
+    """ATASCII stream reader."""
+
+
+def getregentry() -> codecs.CodecInfo:
+    """Return the codec registry entry."""
+    return codecs.CodecInfo(
+        name='atascii',
+        encode=Codec().encode,
+        decode=Codec().decode,  # type: ignore[arg-type]
+        incrementalencoder=IncrementalEncoder,
+        incrementaldecoder=IncrementalDecoder,
+        streamreader=StreamReader,
+        streamwriter=StreamWriter,
+    )
+
+
+def getaliases() -> Tuple[str, ...]:
+    """Return codec aliases."""
+    return ('atari8bit', 'atari_8bit')
+
+
+# Build encoding table preferring normal bytes (0x00-0x7F) over inverse
+# (0x80-0xFF).  codecs.charmap_build() picks the last occurrence, which
+# maps printable characters to the inverse-video range.  We fix this by
+# overwriting with normal-range entries so they take priority.
+# Exception: '\n' must still encode to 0x9B (ATASCII EOL), not 0x0A.
+def _build_encoding_table() -> Dict[int, int]:
+    table: Dict[int, int] = codecs.charmap_build(DECODING_TABLE)
+    for byte_val in range(0x80):
+        table[ord(DECODING_TABLE[byte_val])] = byte_val
+    # '\n' at 0x0A must encode to 0x9B (ATASCII EOL), not 0x0A
+    table[ord('\n')] = 0x9B
+    return table
+
+
+ENCODING_TABLE = _build_encoding_table()

--- a/telnetlib3/server.py
+++ b/telnetlib3/server.py
@@ -1041,6 +1041,7 @@ def parse_server_args() -> Dict[str, Any]:
         result["pty_raw"] = False
 
     # Auto-enable force_binary for retro BBS encodings that use high-bit bytes.
+    # local
     from .encodings import FORCE_BINARY_ENCODINGS  # pylint: disable=import-outside-toplevel
 
     if result["encoding"].lower().replace('-', '_') in FORCE_BINARY_ENCODINGS:

--- a/telnetlib3/server.py
+++ b/telnetlib3/server.py
@@ -1025,6 +1025,13 @@ def parse_server_args() -> Dict[str, Any]:
         result["pty_exec"] = None
         result["pty_fork_limit"] = 0
         result["pty_raw"] = False
+
+    # Auto-enable force_binary for retro BBS encodings that use high-bit bytes.
+    from .encodings import FORCE_BINARY_ENCODINGS  # pylint: disable=import-outside-toplevel
+
+    if result["encoding"].lower().replace('-', '_') in FORCE_BINARY_ENCODINGS:
+        result["force_binary"] = True
+
     return result
 
 

--- a/telnetlib3/server.py
+++ b/telnetlib3/server.py
@@ -59,7 +59,7 @@ class CONFIG(NamedTuple):
     connect_maxwait: float = 1.5
     pty_exec: Optional[str] = None
     pty_args: Optional[List[str]] = None
-    pty_raw: bool = False
+    pty_raw: bool = True
     robot_check: bool = False
     pty_fork_limit: int = 0
     status_interval: int = 20
@@ -989,11 +989,21 @@ def parse_server_args() -> Dict[str, Any]:
             help="limit concurrent PTY connections (0 disables)",
         )
         parser.add_argument(
+            "--line-mode",
+            action="store_true",
+            default=False,
+            help="use cooked PTY mode with echo for --pty-exec instead of raw "
+            "mode.  By default PTY echo is disabled (raw mode), which is "
+            "correct for programs that handle their own terminal I/O "
+            "(curses, blessed, ucs-detect).",
+        )
+        # Hidden backwards-compat: --pty-raw was the default since 2.5,
+        # keep it as a silent no-op so existing scripts don't break.
+        parser.add_argument(
             "--pty-raw",
             action="store_true",
-            default=_config.pty_raw,
-            help="raw mode for --pty-exec: disable PTY echo for programs that "
-            "handle their own terminal I/O (curses, blessed, ucs-detect)",
+            default=False,
+            help=argparse.SUPPRESS,
         )
     parser.add_argument(
         "--robot-check",
@@ -1021,6 +1031,10 @@ def parse_server_args() -> Dict[str, Any]:
     )
     result = vars(parser.parse_args(argv))
     result["pty_args"] = pty_args if PTY_SUPPORT else None
+    # --pty-raw is a hidden no-op (raw is now the default);
+    # --line-mode opts out of raw mode.
+    result.pop("pty_raw", None)
+    result["pty_raw"] = not result.pop("line_mode", False)
     if not PTY_SUPPORT:
         result["pty_exec"] = None
         result["pty_fork_limit"] = 0

--- a/telnetlib3/server_base.py
+++ b/telnetlib3/server_base.py
@@ -195,7 +195,7 @@ class BaseServer(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                 loop = asyncio.get_event_loop()
                 loop.create_task(coro)
 
-    def data_received(self, data: bytes) -> None:
+    def data_received(self, data: bytes) -> None:  # pylint: disable=too-complex
         """
         Process bytes received by transport.
 

--- a/telnetlib3/server_base.py
+++ b/telnetlib3/server_base.py
@@ -13,8 +13,8 @@ from typing import Any, Type, Union, Callable, Optional
 
 # local
 from ._types import ShellCallback
-from .accessories import TRACE, hexdump
 from .telopt import theNULL
+from .accessories import TRACE, hexdump
 from .stream_reader import TelnetReader, TelnetReaderUnicode
 from .stream_writer import TelnetWriter, TelnetWriterUnicode
 

--- a/telnetlib3/server_base.py
+++ b/telnetlib3/server_base.py
@@ -13,6 +13,7 @@ from typing import Any, Type, Union, Callable, Optional
 
 # local
 from ._types import ShellCallback
+from .accessories import TRACE, hexdump
 from .telopt import theNULL
 from .stream_reader import TelnetReader, TelnetReaderUnicode
 from .stream_writer import TelnetWriter, TelnetWriterUnicode
@@ -211,6 +212,8 @@ class BaseServer(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         # more simply by processing a "byte at a time", but, this "batch and seek" solution can be
         # hundreds of times faster though much more complicated.
         #
+        if logger.isEnabledFor(TRACE):
+            logger.log(TRACE, "recv %d bytes\n%s", len(data), hexdump(data, prefix="<<  "))
         self._last_received = datetime.datetime.now()
         self._rx_bytes += len(data)
         assert self.writer is not None

--- a/telnetlib3/server_fingerprinting.py
+++ b/telnetlib3/server_fingerprinting.py
@@ -22,6 +22,9 @@ import datetime
 import subprocess
 from typing import Any
 
+# 3rd party
+from wcwidth.escape_sequences import ZERO_WIDTH_PATTERN as _ZERO_WIDTH_STR_PATTERN
+
 # local
 from . import fingerprinting as _fps
 from .telopt import (
@@ -94,9 +97,8 @@ _MENU_ANSI_RE = re.compile(rb"[\[(](\d+)[\])]\s*ANSI", re.IGNORECASE)
 _GB_BIG5_RE = re.compile(rb"(?i)(?:^|[^a-zA-Z0-9])gb\s*/\s*big\s*5(?:[^a-zA-Z0-9]|$)")
 
 # Strip ANSI/VT100 escape sequences from raw bytes for pattern matching.
-_ANSI_STRIP_RE = re.compile(
-    rb"\x1b(?:\[[0-9;?]*[A-Za-z]|\][^\x07]*\x07|[()][012AB]|[=>NOHMDEc78])"
-)
+# Re-use wcwidth's comprehensive pattern (CSI, OSC, DCS, APC, PM, charset, Fe, Fp).
+_ANSI_STRIP_RE = re.compile(_ZERO_WIDTH_STR_PATTERN.pattern.encode("ascii"))
 
 # Match "Press [.ESC.] twice" botcheck prompts (e.g. Mystic BBS).
 _ESC_TWICE_RE = re.compile(rb"(?i)press\s+\[?\.?esc\.?\]?\s+twice")

--- a/telnetlib3/server_fingerprinting.py
+++ b/telnetlib3/server_fingerprinting.py
@@ -461,7 +461,7 @@ async def fingerprinting_client_shell(
         writer.close()
 
 
-async def _fingerprint_session(  # noqa: E501 ; pylint: disable=too-many-locals,too-many-branches,too-many-statements
+async def _fingerprint_session(  # noqa: E501 ; pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-complex
     reader: TelnetReader,
     writer: TelnetWriter,
     *,
@@ -948,7 +948,7 @@ def _respond_to_dsr(
     cursor.advance(chunk[pos:])
 
 
-async def _read_banner_until_quiet(  # pylint: disable=too-many-positional-arguments
+async def _read_banner_until_quiet(  # noqa: E501 ; pylint: disable=too-many-positional-arguments,too-complex,too-many-nested-blocks
     reader: TelnetReader,
     quiet_time: float = 2.0,
     max_wait: float = 8.0,

--- a/telnetlib3/server_shell.py
+++ b/telnetlib3/server_shell.py
@@ -248,25 +248,6 @@ def character_dump(kb_limit: int) -> Generator[str, None, None]:
     yield "\033[1G" + "wrote " + str(num_bytes) + " bytes"
 
 
-async def get_next_ascii(
-    reader: Union[TelnetReader, TelnetReaderUnicode],
-    writer: Union[TelnetWriter, TelnetWriterUnicode],
-) -> Optional[str]:
-    """Accept the next non-ANSI-escape character from reader."""
-    _reader = cast(TelnetReaderUnicode, reader)
-    escape_sequence = False
-    while not writer.is_closing():
-        next_char = await _reader.read(1)
-        if next_char == "\x1b":
-            escape_sequence = True
-        elif escape_sequence:
-            if 61 <= ord(next_char) <= 90 or 97 <= ord(next_char) <= 122:
-                escape_sequence = False
-        else:
-            return next_char
-    return None
-
-
 @types.coroutine
 def readline(
     _reader: Union[TelnetReader, TelnetReaderUnicode],

--- a/telnetlib3/stream_writer.py
+++ b/telnetlib3/stream_writer.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # local
 from . import slc
-from .accessories import TRACE, hexdump
 from .mud import (
     zmp_decode,
     atcp_decode,
@@ -100,6 +99,7 @@ from .telopt import (
     name_commands,
     option_from_name,
 )
+from .accessories import TRACE, hexdump
 
 __all__ = ("TelnetWriter", "TelnetWriterUnicode")
 

--- a/telnetlib3/stream_writer.py
+++ b/telnetlib3/stream_writer.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # local
 from . import slc
+from .accessories import TRACE, hexdump
 from .mud import (
     zmp_decode,
     atcp_decode,
@@ -891,6 +892,8 @@ class TelnetWriter:
         assert isinstance(buf, (bytes, bytearray)), buf
         assert buf and buf.startswith(IAC), buf
         if not self.is_closing():
+            if self.log.isEnabledFor(TRACE):
+                self.log.log(TRACE, "send IAC %d bytes\n%s", len(buf), hexdump(buf, prefix=">>  "))
             self._transport.write(buf)
             if hasattr(self._protocol, "_tx_bytes"):
                 self._protocol._tx_bytes += len(buf)
@@ -2113,6 +2116,10 @@ class TelnetWriter:
                 # greater than 127, but it was removed for performance.
                 buf = self._escape_iac(buf)
 
+            if self.log.isEnabledFor(TRACE):
+                self.log.log(
+                    TRACE, "send %d bytes\n%s", len(buf), hexdump(buf, prefix=">>  ")
+                )
             self._transport.write(buf)
             if hasattr(self._protocol, "_tx_bytes"):
                 self._protocol._tx_bytes += len(buf)

--- a/telnetlib3/tests/test_accessories_extra.py
+++ b/telnetlib3/tests/test_accessories_extra.py
@@ -8,7 +8,52 @@ from collections import OrderedDict
 import pytest
 
 # local
-from telnetlib3.accessories import make_logger, repr_mapping, function_lookup, make_reader_task
+from telnetlib3.accessories import (
+    TRACE,
+    hexdump,
+    make_logger,
+    repr_mapping,
+    function_lookup,
+    make_reader_task,
+)
+
+
+def test_trace_level_registered():
+    assert TRACE == 5
+    assert logging.getLevelName(TRACE) == "TRACE"
+    assert logging.getLevelName("TRACE") == TRACE
+
+
+def test_hexdump_short():
+    data = b"Hello World\r\n"
+    result = hexdump(data)
+    assert "48 65 6c 6c 6f 20 57 6f" in result
+    assert "72 6c 64 0d 0a" in result
+    assert "|Hello World..|" in result
+
+
+def test_hexdump_two_rows():
+    data = bytes(range(32))
+    result = hexdump(data)
+    lines = result.splitlines()
+    assert len(lines) == 2
+    assert lines[0].startswith("00000000")
+    assert lines[1].startswith("00000010")
+
+
+def test_hexdump_prefix():
+    result = hexdump(b"\xff\xfd\x18", prefix=">>  ")
+    assert result.startswith(">>  00000000")
+    assert "ff fd 18" in result
+
+
+def test_hexdump_empty():
+    assert hexdump(b"") == ""
+
+
+def test_make_logger_trace_level():
+    logger = make_logger("acc_trace", loglevel="trace")
+    assert logger.isEnabledFor(TRACE)
 
 
 def test_make_logger_no_file():

--- a/telnetlib3/tests/test_atascii_codec.py
+++ b/telnetlib3/tests/test_atascii_codec.py
@@ -1,0 +1,240 @@
+"""Tests for the ATASCII (Atari 8-bit) codec."""
+
+# std imports
+import codecs
+
+# 3rd party
+import pytest
+
+# local
+import telnetlib3  # noqa: F401 - registers codecs
+from telnetlib3.encodings import atascii
+
+
+def test_codec_lookup():
+    info = codecs.lookup('atascii')
+    assert info.name == 'atascii'
+
+
+@pytest.mark.parametrize("alias", ['atari8bit', 'atari_8bit'])
+def test_codec_aliases(alias):
+    info = codecs.lookup(alias)
+    assert info.name == 'atascii'
+
+
+def test_ascii_letters_uppercase():
+    data = bytes(range(0x41, 0x5B))
+    assert data.decode('atascii') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+
+def test_ascii_letters_lowercase():
+    data = bytes(range(0x61, 0x7B))
+    assert data.decode('atascii') == 'abcdefghijklmnopqrstuvwxyz'
+
+
+def test_digits():
+    data = bytes(range(0x30, 0x3A))
+    assert data.decode('atascii') == '0123456789'
+
+
+def test_space():
+    assert b'\x20'.decode('atascii') == ' '
+
+
+@pytest.mark.parametrize("byte_val,expected", [
+    pytest.param(0x00, '\u2665', id='heart'),
+    pytest.param(0x01, '\u251c', id='box_vert_right'),
+    pytest.param(0x08, '\u25e2', id='lower_right_triangle'),
+    pytest.param(0x09, '\u2597', id='quadrant_lower_right'),
+    pytest.param(0x10, '\u2663', id='club'),
+    pytest.param(0x12, '\u2500', id='horizontal_line'),
+    pytest.param(0x14, '\u25cf', id='black_circle'),
+    pytest.param(0x15, '\u2584', id='lower_half_block'),
+    pytest.param(0x19, '\u258c', id='left_half_block'),
+    pytest.param(0x1B, '\u241b', id='symbol_for_escape'),
+])
+def test_graphics_chars(byte_val, expected):
+    assert bytes([byte_val]).decode('atascii') == expected
+
+
+@pytest.mark.parametrize("byte_val,expected", [
+    pytest.param(0x1C, '\u2191', id='cursor_up'),
+    pytest.param(0x1D, '\u2193', id='cursor_down'),
+    pytest.param(0x1E, '\u2190', id='cursor_left'),
+    pytest.param(0x1F, '\u2192', id='cursor_right'),
+])
+def test_cursor_arrows(byte_val, expected):
+    assert bytes([byte_val]).decode('atascii') == expected
+
+
+@pytest.mark.parametrize("byte_val,expected", [
+    pytest.param(0x60, '\u2666', id='diamond'),
+    pytest.param(0x7B, '\u2660', id='spade'),
+    pytest.param(0x7C, '|', id='pipe'),
+    pytest.param(0x7D, '\u21b0', id='clear_screen'),
+    pytest.param(0x7E, '\u25c0', id='backspace_triangle'),
+    pytest.param(0x7F, '\u25b6', id='tab_triangle'),
+])
+def test_special_glyphs(byte_val, expected):
+    assert bytes([byte_val]).decode('atascii') == expected
+
+
+def test_atascii_eol():
+    assert b'\x9b'.decode('atascii') == '\n'
+
+
+@pytest.mark.parametrize("byte_val,expected", [
+    pytest.param(0x82, '\u258a', id='left_three_quarters'),
+    pytest.param(0x88, '\u25e4', id='upper_left_triangle'),
+    pytest.param(0x89, '\u259b', id='quadrant_UL_UR_LL'),
+    pytest.param(0x8A, '\u25e5', id='upper_right_triangle'),
+    pytest.param(0x8B, '\u2599', id='quadrant_UL_LL_LR'),
+    pytest.param(0x8C, '\u259f', id='quadrant_UR_LL_LR'),
+    pytest.param(0x8D, '\u2586', id='lower_three_quarters'),
+    pytest.param(0x8E, '\U0001fb85', id='upper_three_quarters'),
+    pytest.param(0x8F, '\u259c', id='quadrant_UL_UR_LR'),
+    pytest.param(0x94, '\u25d8', id='inverse_bullet'),
+    pytest.param(0x95, '\u2580', id='upper_half_block'),
+    pytest.param(0x96, '\U0001fb8a', id='right_three_quarters'),
+    pytest.param(0x99, '\u2590', id='right_half_block'),
+    pytest.param(0xA0, '\u2588', id='full_block'),
+])
+def test_inverse_distinct_glyphs(byte_val, expected):
+    assert bytes([byte_val]).decode('atascii') == expected
+
+
+def test_inverse_shared_glyphs():
+    for byte_val in (0x80, 0x81, 0x83, 0x84, 0x85, 0x86, 0x87):
+        normal = bytes([byte_val & 0x7F]).decode('atascii')
+        inverse = bytes([byte_val]).decode('atascii')
+        assert inverse == normal
+
+
+def test_inverse_ascii_range():
+    for byte_val in range(0xA1, 0xFB):
+        normal = bytes([byte_val & 0x7F]).decode('atascii')
+        inverse = bytes([byte_val]).decode('atascii')
+        assert inverse == normal
+
+
+def test_full_decode_no_crash():
+    data = bytes(range(256))
+    result = data.decode('atascii')
+    assert len(result) == 256
+
+
+def test_encode_eol():
+    encoded, length = codecs.lookup('atascii').encode('\n')
+    assert encoded == b'\x9b'
+    assert length == 1
+
+
+def test_encode_unique_chars():
+    encoded, _ = codecs.lookup('atascii').encode('\u258a')
+    assert encoded == b'\x82'
+    encoded, _ = codecs.lookup('atascii').encode('\u25d8')
+    assert encoded == b'\x94'
+    encoded, _ = codecs.lookup('atascii').encode('\u2588')
+    assert encoded == b'\xa0'
+
+
+def test_encode_charmap_prefers_normal_byte():
+    encoded, _ = codecs.lookup('atascii').encode('\u2665')
+    assert encoded == b'\x00'
+    encoded, _ = codecs.lookup('atascii').encode('A')
+    assert encoded == b'\x41'
+
+
+def test_incremental_decoder():
+    decoder = codecs.getincrementaldecoder('atascii')()
+    assert decoder.decode(b'\x00', False) == '\u2665'
+    assert decoder.decode(b'AB', True) == 'AB'
+
+
+def test_incremental_encoder():
+    encoder = codecs.getincrementalencoder('atascii')()
+    assert encoder.encode('\u258a', False) == b'\x82'
+    assert encoder.encode('\n', True) == b'\x9b'
+
+
+def test_strict_error_on_unencodable():
+    with pytest.raises(UnicodeEncodeError):
+        '\u00e9'.encode('atascii')
+
+
+def test_replace_error_mode():
+    result = '\u00e9'.encode('atascii', errors='replace')
+    assert result == b'\x3f'
+
+
+def test_ignore_error_mode():
+    result = '\u00e9'.encode('atascii', errors='ignore')
+    assert result == b''
+
+
+def test_encode_cr_as_eol():
+    encoded, length = codecs.lookup('atascii').encode('\r')
+    assert encoded == b'\x9b'
+    assert length == 1
+
+
+def test_encode_crlf_as_single_eol():
+    encoded, length = codecs.lookup('atascii').encode('\r\n')
+    assert encoded == b'\x9b'
+    assert length == 1
+
+
+def test_encode_mixed_line_endings():
+    encoded, _ = codecs.lookup('atascii').encode('hello\r\nworld\r')
+    hello_eol = 'hello\n'.encode('atascii')
+    world_eol = 'world\n'.encode('atascii')
+    assert encoded == hello_eol + world_eol
+
+
+def test_incremental_encoder_cr_then_lf():
+    encoder = codecs.getincrementalencoder('atascii')()
+    result = encoder.encode('hello\r', final=False)
+    assert result == 'hello'.encode('atascii')
+    result = encoder.encode('\nworld', final=True)
+    assert result == '\nworld'.encode('atascii')
+
+
+def test_incremental_encoder_cr_then_other():
+    encoder = codecs.getincrementalencoder('atascii')()
+    result = encoder.encode('A\r', final=False)
+    assert result == 'A'.encode('atascii')
+    result = encoder.encode('B', final=True)
+    assert result == '\nB'.encode('atascii')
+
+
+def test_incremental_encoder_cr_final():
+    encoder = codecs.getincrementalencoder('atascii')()
+    result = encoder.encode('end\r', final=True)
+    assert result == 'end\n'.encode('atascii')
+
+
+def test_incremental_encoder_reset():
+    encoder = codecs.getincrementalencoder('atascii')()
+    encoder.encode('A\r', final=False)
+    encoder.reset()
+    assert encoder.getstate() == 0
+
+
+def test_incremental_encoder_getstate_setstate():
+    encoder = codecs.getincrementalencoder('atascii')()
+    encoder.encode('A\r', final=False)
+    assert encoder.getstate() == 1
+    state = encoder.getstate()
+    encoder2 = codecs.getincrementalencoder('atascii')()
+    encoder2.setstate(state)
+    result = encoder2.encode('\n', final=True)
+    assert result == b'\x9b'
+
+
+def test_native_graphics_0x0a_0x0d():
+    assert b'\x0a'.decode('atascii') == '\u25e3'
+    assert b'\x0d'.decode('atascii') == '\U0001fb82'
+
+
+def test_decoding_table_length():
+    assert len(atascii.DECODING_TABLE) == 256

--- a/telnetlib3/tests/test_client_shell.py
+++ b/telnetlib3/tests/test_client_shell.py
@@ -1,0 +1,214 @@
+"""Tests for telnetlib3.client_shell — Terminal mode handling."""
+
+# std imports
+import sys
+import types
+
+# 3rd party
+import pytest
+
+if sys.platform == "win32":
+    pytest.skip("POSIX-only tests", allow_module_level=True)
+
+# std imports
+# std imports (POSIX only)
+import termios  # noqa: E402
+
+# local
+from telnetlib3.client_shell import (  # noqa: E402
+    _INPUT_XLAT,
+    _INPUT_SEQ_XLAT,
+    Terminal,
+    InputFilter,
+)
+
+
+def _make_writer(will_echo: bool = False, raw_mode: bool = False) -> object:
+    """Build a minimal mock writer with the attributes Terminal needs."""
+    writer = types.SimpleNamespace(
+        will_echo=will_echo,
+        log=types.SimpleNamespace(debug=lambda *a, **kw: None),
+    )
+    if raw_mode:
+        writer._raw_mode = True
+    return writer
+
+
+def _cooked_mode() -> "Terminal.ModeDef":
+    """Return a typical cooked-mode ModeDef with canonical input enabled."""
+    return Terminal.ModeDef(
+        iflag=termios.BRKINT | termios.ICRNL | termios.IXON,
+        oflag=termios.OPOST | termios.ONLCR,
+        cflag=termios.CS8 | termios.CREAD,
+        lflag=termios.ICANON | termios.ECHO | termios.ISIG | termios.IEXTEN,
+        ispeed=termios.B38400,
+        ospeed=termios.B38400,
+        cc=[b'\x00'] * termios.NCCS,
+    )
+
+
+class TestDetermineMode:
+    def test_linemode_when_no_echo_no_raw(self) -> None:
+        writer = _make_writer(will_echo=False, raw_mode=False)
+        term = Terminal.__new__(Terminal)
+        term.telnet_writer = writer
+        mode = _cooked_mode()
+        result = term.determine_mode(mode)
+        assert result is mode
+
+    def test_raw_mode_when_will_echo(self) -> None:
+        writer = _make_writer(will_echo=True, raw_mode=False)
+        term = Terminal.__new__(Terminal)
+        term.telnet_writer = writer
+        mode = _cooked_mode()
+        result = term.determine_mode(mode)
+        assert result is not mode
+        assert not (result.lflag & termios.ICANON)
+        assert not (result.lflag & termios.ECHO)
+
+    def test_raw_mode_when_force_raw(self) -> None:
+        writer = _make_writer(will_echo=False, raw_mode=True)
+        term = Terminal.__new__(Terminal)
+        term.telnet_writer = writer
+        mode = _cooked_mode()
+        result = term.determine_mode(mode)
+        assert result is not mode
+        assert not (result.lflag & termios.ICANON)
+        assert not (result.lflag & termios.ECHO)
+        assert not (result.oflag & termios.OPOST)
+
+    def test_raw_mode_when_both_echo_and_raw(self) -> None:
+        writer = _make_writer(will_echo=True, raw_mode=True)
+        term = Terminal.__new__(Terminal)
+        term.telnet_writer = writer
+        mode = _cooked_mode()
+        result = term.determine_mode(mode)
+        assert result is not mode
+        assert not (result.lflag & termios.ICANON)
+        assert not (result.lflag & termios.ECHO)
+
+
+class TestInputXlat:
+    def test_atascii_del_to_backspace(self) -> None:
+        assert _INPUT_XLAT["atascii"][0x7F] == 0x7E
+
+    def test_atascii_bs_to_backspace(self) -> None:
+        assert _INPUT_XLAT["atascii"][0x08] == 0x7E
+
+    def test_atascii_cr_to_eol(self) -> None:
+        assert _INPUT_XLAT["atascii"][0x0D] == 0x9B
+
+    def test_atascii_lf_to_eol(self) -> None:
+        assert _INPUT_XLAT["atascii"][0x0A] == 0x9B
+
+    def test_petscii_del_to_backspace(self) -> None:
+        assert _INPUT_XLAT["petscii"][0x7F] == 0x14
+
+    def test_petscii_bs_to_backspace(self) -> None:
+        assert _INPUT_XLAT["petscii"][0x08] == 0x14
+
+    def test_normal_bytes_not_in_xlat(self) -> None:
+        xlat = _INPUT_XLAT["atascii"]
+        for b in (ord('a'), ord('A'), ord('1'), ord(' ')):
+            assert b not in xlat
+
+
+class TestInputFilterAtascii:
+    @staticmethod
+    def _make_filter() -> InputFilter:
+        return InputFilter(
+            _INPUT_SEQ_XLAT["atascii"], _INPUT_XLAT["atascii"]
+        )
+
+    @pytest.mark.parametrize("seq,expected", list(_INPUT_SEQ_XLAT["atascii"].items()))
+    def test_sequence_translated(self, seq: bytes, expected: bytes) -> None:
+        f = self._make_filter()
+        assert f.feed(seq) == expected
+
+    def test_passthrough_ascii(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"hello") == b"hello"
+
+    def test_mixed_text_and_sequence(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"hi\x1b[Alo") == b"hi\x1clo"
+
+    def test_multiple_sequences(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b[A\x1b[B\x1b[C\x1b[D") == b"\x1c\x1d\x1f\x1e"
+
+    def test_single_byte_xlat_applied(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x7f") == b"\x7e"
+        assert f.feed(b"\x08") == b"\x7e"
+
+    def test_cr_to_atascii_eol(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\r") == b"\x9b"
+
+    def test_lf_to_atascii_eol(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\n") == b"\x9b"
+
+    def test_text_with_enter(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"hello\r") == b"hello\x9b"
+
+    def test_split_sequence_buffered(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b") == b""
+        assert f.feed(b"[A") == b"\x1c"
+
+    def test_split_sequence_mid_csi(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b[") == b""
+        assert f.feed(b"A") == b"\x1c"
+
+    def test_bare_esc_flushed_on_non_prefix(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b") == b""
+        assert f.feed(b"x") == b"\x1bx"
+
+    def test_delete_key_sequence(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b[3~") == b"\x7e"
+
+    def test_ss3_arrow_keys(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1bOA") == b"\x1c"
+        assert f.feed(b"\x1bOD") == b"\x1e"
+
+
+class TestInputFilterPetscii:
+    @staticmethod
+    def _make_filter() -> InputFilter:
+        return InputFilter(
+            _INPUT_SEQ_XLAT["petscii"], _INPUT_XLAT["petscii"]
+        )
+
+    @pytest.mark.parametrize("seq,expected", list(_INPUT_SEQ_XLAT["petscii"].items()))
+    def test_sequence_translated(self, seq: bytes, expected: bytes) -> None:
+        f = self._make_filter()
+        assert f.feed(seq) == expected
+
+    def test_home_key(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b[H") == b"\x13"
+
+    def test_insert_key(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x1b[2~") == b"\x94"
+
+    def test_single_byte_xlat_applied(self) -> None:
+        f = self._make_filter()
+        assert f.feed(b"\x7f") == b"\x14"
+
+
+class TestInputFilterEmpty:
+    def test_no_xlat_passthrough(self) -> None:
+        f = InputFilter({}, {})
+        assert f.feed(b"hello\x1b[Aworld") == b"hello\x1b[Aworld"
+
+    def test_empty_feed(self) -> None:
+        f = InputFilter({}, {})
+        assert f.feed(b"") == b""

--- a/telnetlib3/tests/test_client_unit.py
+++ b/telnetlib3/tests/test_client_unit.py
@@ -62,6 +62,36 @@ async def test_send_charset_null_default():
     assert c.send_charset(["utf-8"]) == "utf-8"
 
 
+@pytest.mark.parametrize(
+    "offered,expected",
+    [
+        pytest.param(["iso-8859-02"], "iso-8859-02", id="iso_leading_zero"),
+        pytest.param(["iso 8859-02"], "iso 8859-02", id="iso_space_leading_zero"),
+        pytest.param(["cp-1250"], "cp-1250", id="cp_hyphen"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_send_charset_normalization(offered, expected):
+    c = _make_client(encoding=False)
+    c.default_encoding = None
+    assert c.send_charset(offered) == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        pytest.param("iso-8859-02", "iso-8859-2", id="iso_leading_zero"),
+        pytest.param("iso 8859-02", "iso-8859-2", id="iso_space_leading_zero"),
+        pytest.param("cp-1250", "cp1250", id="cp_hyphen"),
+        pytest.param("UTF-8", "UTF-8", id="passthrough"),
+        pytest.param("iso-8859-15", "iso-8859-15", id="no_leading_zero"),
+        pytest.param("x-penn-def", "x-penn-def", id="unknown_passthrough"),
+    ],
+)
+def test_normalize_charset_name(name, expected):
+    assert cl.TelnetClient._normalize_charset_name(name) == expected
+
+
 @pytest.mark.asyncio
 async def test_send_env():
     c = _make_client(term="xterm", cols=132, rows=43)

--- a/telnetlib3/tests/test_color_filter.py
+++ b/telnetlib3/tests/test_color_filter.py
@@ -6,10 +6,10 @@ import pytest
 # local
 from telnetlib3.color_filter import (
     PALETTES,
-    AtasciiControlFilter,
     ColorConfig,
     ColorFilter,
     PetsciiColorFilter,
+    AtasciiControlFilter,
     _adjust_color,
     _is_foreground_code,
     _sgr_code_to_palette_index,

--- a/telnetlib3/tests/test_core.py
+++ b/telnetlib3/tests/test_core.py
@@ -500,7 +500,7 @@ async def test_telnet_client_cmdline_stdin_pipe(bind_host, unused_tcp_port):
             logfile_output = f.read().splitlines()
         assert stdout == (
             b"Escape character is '^]'.\n"
-            b"Press Return to continue:\r\ngoodbye.\n"
+            b"Press Return to continue:\r\ngoodbye.\r\n"
             b"\x1b[m\nConnection closed by foreign host.\n"
         )
         assert len(logfile_output) in (2, 3), logfile

--- a/telnetlib3/tests/test_core.py
+++ b/telnetlib3/tests/test_core.py
@@ -450,7 +450,7 @@ async def test_telnet_client_tty_cmdline(bind_host, unused_tcp_port):
         await proc.expect(pexpect.EOF, async_=True, timeout=5)
         assert proc.before == (
             b"Escape character is '^]'.\r\n"
-            b"hello, space cadet.\r\r\n"
+            b"hello, space cadet.\r\n"
             b"\x1b[m\r\n"
             b"Connection closed by foreign host.\r\n"
         )

--- a/telnetlib3/tests/test_core.py
+++ b/telnetlib3/tests/test_core.py
@@ -478,7 +478,6 @@ async def test_telnet_client_cmdline_stdin_pipe(bind_host, unused_tcp_port):
         writer.write("Press Return to continue:")
         inp = await reader.readline()
         if inp:
-            writer.echo(inp)
             writer.write("\ngoodbye.\n")
         await writer.drain()
         writer.close()

--- a/telnetlib3/tests/test_guard_integration.py
+++ b/telnetlib3/tests/test_guard_integration.py
@@ -6,6 +6,7 @@ import functools
 import pytest
 
 # local
+from telnetlib3 import server_fingerprinting as sfp
 from telnetlib3.guard_shells import (
     ConnectionCounter,
     _read_line,
@@ -15,7 +16,6 @@ from telnetlib3.guard_shells import (
     _latin1_reading,
 )
 from telnetlib3.stream_reader import TelnetReaderUnicode
-from telnetlib3 import server_fingerprinting as sfp
 
 
 async def test_connection_counter_integration():
@@ -409,8 +409,9 @@ async def test_without_latin1_reading_strict_crashes():
 
 async def test_fingerprint_scanner_defeats_robot_check(unused_tcp_port):
     """Fingerprint scanner's virtual cursor defeats the server's robot_check."""
+    # local
+    from telnetlib3.guard_shells import _TEST_CHAR, _measure_width  # noqa: PLC0415
     from telnetlib3.tests.accessories import create_server  # noqa: PLC0415
-    from telnetlib3.guard_shells import _measure_width, _TEST_CHAR  # noqa: PLC0415
 
     measured_width: list[int | None] = []
 
@@ -430,6 +431,7 @@ async def test_fingerprint_scanner_defeats_robot_check(unused_tcp_port):
         shell=guarded_shell,
         connect_maxwait=0.5,
     ):
+        # local
         import telnetlib3  # noqa: PLC0415
 
         shell = functools.partial(

--- a/telnetlib3/tests/test_petscii_codec.py
+++ b/telnetlib3/tests/test_petscii_codec.py
@@ -1,0 +1,101 @@
+"""Tests for the PETSCII (Commodore 64/128) codec."""
+
+# std imports
+import codecs
+
+# 3rd party
+import pytest
+
+# local
+import telnetlib3  # noqa: F401 - registers codecs
+from telnetlib3.encodings import petscii
+
+
+def test_codec_lookup():
+    info = codecs.lookup('petscii')
+    assert info.name == 'petscii'
+
+
+@pytest.mark.parametrize("alias", ['cbm', 'commodore', 'c64', 'c128'])
+def test_codec_aliases(alias):
+    info = codecs.lookup(alias)
+    assert info.name == 'petscii'
+
+
+def test_digits():
+    data = bytes(range(0x30, 0x3A))
+    assert data.decode('petscii') == '0123456789'
+
+
+def test_space():
+    assert b'\x20'.decode('petscii') == ' '
+
+
+def test_lowercase_at_41_5A():
+    data = bytes(range(0x41, 0x5B))
+    assert data.decode('petscii') == 'abcdefghijklmnopqrstuvwxyz'
+
+
+def test_uppercase_at_C1_DA():
+    data = bytes(range(0xC1, 0xDB))
+    assert data.decode('petscii') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+
+def test_return():
+    assert b'\x0d'.decode('petscii') == '\r'
+
+
+@pytest.mark.parametrize("byte_val,expected", [
+    pytest.param(0x5C, '\u00a3', id='pound_sign'),
+    pytest.param(0x5E, '\u2191', id='up_arrow'),
+    pytest.param(0x5F, '\u2190', id='left_arrow'),
+    pytest.param(0x61, '\u2660', id='spade'),
+    pytest.param(0x7E, '\u03c0', id='pi'),
+    pytest.param(0x78, '\u2663', id='club'),
+    pytest.param(0x7A, '\u2666', id='diamond'),
+    pytest.param(0x73, '\u2665', id='heart'),
+])
+def test_graphics_chars(byte_val, expected):
+    assert bytes([byte_val]).decode('petscii') == expected
+
+
+def test_full_decode_no_crash():
+    data = bytes(range(256))
+    result = data.decode('petscii')
+    assert len(result) == 256
+
+
+def test_encode_lowercase():
+    encoded, length = codecs.lookup('petscii').encode('hello')
+    assert encoded == bytes([0x48, 0x45, 0x4c, 0x4c, 0x4f])
+    assert length == 5
+
+
+def test_encode_uppercase():
+    encoded, length = codecs.lookup('petscii').encode('HELLO')
+    assert encoded == b'\xc8\xc5\xcc\xcc\xcf'
+    assert length == 5
+
+
+def test_round_trip_digits():
+    for byte_val in range(0x30, 0x3A):
+        original = bytes([byte_val])
+        decoded = original.decode('petscii')
+        re_encoded = decoded.encode('petscii')
+        assert re_encoded == original
+
+
+def test_incremental_decoder():
+    decoder = codecs.getincrementaldecoder('petscii')()
+    assert decoder.decode(b'\xc1', False) == 'A'
+    assert decoder.decode(b'\x42\x43', True) == 'bc'
+
+
+def test_incremental_encoder():
+    encoder = codecs.getincrementalencoder('petscii')()
+    assert encoder.encode('A', False) == b'\xc1'
+    assert encoder.encode('bc', True) == b'\x42\x43'
+
+
+def test_decoding_table_length():
+    assert len(petscii.DECODING_TABLE) == 256

--- a/telnetlib3/tests/test_server_fingerprinting.py
+++ b/telnetlib3/tests/test_server_fingerprinting.py
@@ -969,6 +969,21 @@ async def test_probe_skipped_when_closing(tmp_path):
             id="yn_ansi_wrapped",
         ),
         pytest.param(
+            b"Do you support the ANSI color standard (Yn)? ",
+            b"y\r\n",
+            id="yn_paren_capital_y",
+        ),
+        pytest.param(
+            b"Continue? [Yn]",
+            b"y\r\n",
+            id="yn_bracket_capital_y",
+        ),
+        pytest.param(
+            b"Do something (yN)",
+            b"y\r\n",
+            id="yn_paren_capital_n",
+        ),
+        pytest.param(
             b"More: (Y)es, (N)o, (C)ontinuous?",
             b"C\r\n",
             id="more_continuous",
@@ -982,6 +997,16 @@ async def test_probe_skipped_when_closing(tmp_path):
             b"more (Y/N/C)ontinuous: ",
             b"C\r\n",
             id="more_ync_compact",
+        ),
+        pytest.param(
+            b"Press the BACKSPACE key to detect your terminal type: ",
+            b"\x08",
+            id="backspace_key_telnetbible",
+        ),
+        pytest.param(
+            b"\x1b[1mPress the BACKSPACE key\x1b[0m",
+            b"\x08",
+            id="backspace_key_ansi_wrapped",
         ),
         pytest.param(
             b"\x0cpress del/backspace:",

--- a/telnetlib3/tests/test_server_fingerprinting.py
+++ b/telnetlib3/tests/test_server_fingerprinting.py
@@ -91,12 +91,12 @@ class MockReader:
 
 
 class InteractiveMockReader:
-    """MockReader that gates chunks behind writer responses.
+    """
+    MockReader that gates chunks behind writer responses.
 
-    The first chunk is available immediately.  Each subsequent chunk is
-    released only after the writer has accumulated one more write than
-    before, simulating a server that waits for client input before
-    sending the next prompt.
+    The first chunk is available immediately.  Each subsequent chunk is released only after the
+    writer has accumulated one more write than before, simulating a server that waits for client
+    input before sending the next prompt.
     """
 
     def __init__(self, chunks, writer):
@@ -1162,7 +1162,6 @@ async def test_fingerprinting_shell_no_yn_prompt(tmp_path):
     assert b"yes\r\n" not in writer._writes
 
 
-
 @pytest.mark.asyncio
 async def test_fingerprinting_shell_multi_prompt(tmp_path):
     """Server asks color first, then presents a UTF-8 charset menu."""
@@ -1226,7 +1225,7 @@ async def test_fingerprinting_shell_multi_prompt_max_replies(tmp_path):
     save_path = str(tmp_path / "result.json")
     writer = MockWriter(will_options=[fps.SGA])
     banners = [f"Color? (round {i}) ".encode()
-                for i in range(sfp._MAX_PROMPT_REPLIES + 1)]
+               for i in range(sfp._MAX_PROMPT_REPLIES + 1)]
     reader = InteractiveMockReader(banners, writer)
 
     await sfp.fingerprinting_client_shell(
@@ -1360,7 +1359,7 @@ async def test_fingerprinting_settle_dsr_response(tmp_path):
 
 @pytest.mark.asyncio
 async def test_fingerprinting_shell_ansi_ellipsis_menu(tmp_path):
-    """Worldgroup/MajorBBS ellipsis menu '1 ... English/ANSI' selects '1'."""
+    """Worldgroup/MajorBBS ellipsis-menu selects first numbered option."""
     save_path = str(tmp_path / "result.json")
     writer = MockWriter(will_options=[fps.SGA, fps.ECHO])
     reader = InteractiveMockReader([
@@ -1539,5 +1538,6 @@ def test_virtual_cursor_ansi_stripped():
     pytest.param(b"\x1b\x1b", "atascii", b"\x1b\x1b", id="atascii_esc_esc"),
 ])
 def test_reencode_prompt(response, encoding, expected):
+    # local
     import telnetlib3  # noqa: F401 - registers codecs
     assert sfp._reencode_prompt(response, encoding) == expected

--- a/telnetlib3/tests/test_server_shell_unit.py
+++ b/telnetlib3/tests/test_server_shell_unit.py
@@ -269,22 +269,6 @@ async def test_readline2(input_chars, expected):
 
 
 @pytest.mark.parametrize(
-    "input_chars,closing,expected",
-    [
-        pytest.param(["a"], False, "a", id="normal"),
-        pytest.param(["\x1b", "A", "x"], False, "x", id="skips_escape"),
-        pytest.param([], True, None, id="returns_none_when_closing"),
-        pytest.param(["\x1b", "1", "A", "x"], False, "x", id="escape_non_letter"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_get_next_ascii(input_chars, closing, expected):
-    writer = MockWriter()
-    writer._closing = closing
-    assert await ss.get_next_ascii(MockReader(input_chars), writer) == expected
-
-
-@pytest.mark.parametrize(
     "input_data,expected",
     [
         pytest.param([b"\x1b", b"[", b"1", b"0", b";", b"2", b"0", b"R"], (10, 20), id="valid"),
@@ -357,8 +341,8 @@ async def test_measure_width(monkeypatch, responses, expected):
 @pytest.mark.parametrize(
     "width,expected",
     [
-        pytest.param(2, True, id="width_2"),
-        pytest.param(1, False, id="width_1"),
+        pytest.param(1, True, id="width_1"),
+        pytest.param(2, False, id="width_2"),
         pytest.param(None, False, id="width_none"),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -145,7 +145,7 @@ deps =
     codespell
 commands =
     codespell --skip="*.pyc,htmlcov*,_build,build,*.egg-info,.tox,.git" \
-              --ignore-words-list="wont,nams,flushin,thirdparty,lient,caf" \
+              --ignore-words-list="wont,nams,flushin,thirdparty,lient,caf,alo" \
               --uri-ignore-words-list "*" \
               --summary --count
 


### PR DESCRIPTION
## 2.5.0
- **change**: `telnetlib3-client` now defaults to raw terminal mode (no line buffering, no local echo), which is correct for most servers. Use `--line-mode` to restore line-buffered local-echo behavior.
- **change**: `telnetlib3-server --pty-exec` now defaults to raw PTY mode. Use `--line-mode` to restore cooked PTY mode with echo.
- **change**: `connect_minwait` default reduced to 0 across `BaseClient`, `open_connection()`, and `telnetlib3-client`. Negotiation continues asynchronously. Use `--connect-minwait` to restore a delay if needed, or use `TelnetWriter.wait_for()` in server or client shells to await a specific negotiation state.
- **new**: Color, keyboard input translation and `--encoding` support for ATASCII (ATARI ASCII) and PETSCII (Commodore ASCII).
- **new**: SyncTERM/CTerm font selection sequence detection (`CSI Ps1 ; Ps2 SP D`). Both `telnetlib3-fingerprint` and `telnetlib3-client` detect font switching and auto-switch encoding to the matching codec (e.g. font 36 = ATASCII, 32-35 = PETSCII, 0 = CP437). Explicit `--encoding` takes precedence.
- **new**: `TRACE` log level (5, below `DEBUG`) with hexdump style output for all sent and received bytes. Use `--loglevel=trace`.
- **bugfix**: `robot_check()` now uses a narrow character (space) instead of a wide Unicode character, allowing retro terminal emulators to pass.
- **bugfix**: ATASCII codec now maps bytes 0x0D and 0x0A to CR and LF instead of graphics characters, fixing garbled output when connecting to Atari BBS systems.
- **bugfix**: ATASCII codec normalizes CR and CRLF to the native ATASCII EOL (0x9B) during encoding, so the Return key works correctly.
- **bugfix**: PETSCII bare CR (0x0D) is now normalized to CRLF in raw terminal mode and to LF in `telnetlib3-fingerprint` banners.
- **bugfix**: `telnetlib3-fingerprint` re-encodes prompt responses for retro encodings so servers receive the correct EOL byte.
- **bugfix**: `telnetlib3-fingerprint` no longer crashes with `LookupError` when the server negotiates an unknown charset. Banner formatting falls back to `latin-1`.
- **bugfix**: `TelnetClient.send_charset()` normalises non-standard encoding names (`iso-8859-02` to `iso-8859-2`, `cp-1250` to `cp1250`, etc.).
- **enhancement**: `telnetlib3-fingerprint` responds more like a terminal and to more y/n prompts about colors, encoding, etc. to collect more banners for the https://bbs.modem.xyz/ project.
- **enhancement**: `telnetlib3-fingerprint` banner formatting uses `surrogateescape` error handler, preserving raw high bytes (e.g. CP437 art) as surrogates instead of replacing them with U+FFFD.