### PR TITLE
provide legacy 'import telnetlib' compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ for Python 3.9 and newer.
 This library supports both modern asyncio_ *and* legacy `Blocking API`_.
 
 The python telnetlib.py_ module removed by Python 3.13 is also re-distributed as-is, as a backport.
+In Python 3.13+, ``pip install telnetlib3`` provides a drop-in ``import telnetlib`` shim, so
+existing code using the legacy standard telnet client API continues to work without modification.
 
 See the `Guidebook`_ for examples and the `API documentation`_.
 
@@ -168,27 +170,6 @@ Blocking API
 
 A Synchronous interface, modeled after telnetlib.py_ (client) and miniboa_ (server), with various
 enhancements in protocol negotiation is also provided.  See `sync API documentation`_ for more.
-
-Legacy telnetlib
-----------------
-
-This library contains an *unadulterated copy* of Python 3.12's telnetlib.py_,
-from the standard library before it was removed in Python 3.13.
-
-To migrate code, change import statements:
-
-.. code-block:: python
-
-    # OLD imports:
-    import telnetlib
-
-    # NEW imports:
-    import telnetlib3
-
-``telnetlib3`` did not provide server support, while this library also provides
-both client and server support through a similar Blocking API interface.
-
-See `sync API documentation`_ for details.
 
 Quick Example
 =============

--- a/docs/guidebook.rst
+++ b/docs/guidebook.rst
@@ -811,12 +811,10 @@ Legacy telnetlib Compatibility
 
 Python's ``telnetlib`` was removed in Python 3.13 (`PEP 594
 <https://peps.python.org/pep-0594/>`_). telnetlib3 includes a verbatim copy from Python 3.12 with its original test
-suite::
+suite and a drop-in shim so that ``import telnetlib`` continues to work::
 
-    # OLD:
+    # Both of these work:
     from telnetlib import Telnet
-
-    # NEW:
     from telnetlib3.telnetlib import Telnet
 
 The legacy module has limited negotiation support and is maintained for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ include = [
 [tool.hatch.build.targets.wheel]
 packages = ["telnetlib3"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"telnetlib.py" = "telnetlib.py"
+
 [tool.pylint.main]
 load-plugins = [
     "pylint.extensions.check_elif",
@@ -182,7 +185,7 @@ reports = false
 msg-template = "{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.14"
 strict = true
 disallow_subclassing_any = false
 ignore_missing_imports = true
@@ -193,7 +196,7 @@ module = ["telnetlib3.tests.*"]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["telnetlib3.telnetlib"]
+module = ["telnetlib3.telnetlib", "telnetlib"]
 ignore_errors = true
 
 [tool.black]

--- a/telnetlib.py
+++ b/telnetlib.py
@@ -1,9 +1,2 @@
 """Drop-in shim for telnetlib (removed from stdlib in Python 3.13)."""
-import sys
-
-if sys.version_info >= (3, 13):
-    from telnetlib3.telnetlib import *  # noqa: F401, F403
-else:
-    sys.modules.pop(__name__, None)
-    import telnetlib  # noqa: W0406
-    sys.modules[__name__] = telnetlib
+from telnetlib3.telnetlib import *  # noqa: F401, F403

--- a/telnetlib.py
+++ b/telnetlib.py
@@ -1,0 +1,9 @@
+"""Drop-in shim for telnetlib (removed from stdlib in Python 3.13)."""
+import sys
+
+if sys.version_info >= (3, 13):
+    from telnetlib3.telnetlib import *  # noqa: F401, F403
+else:
+    sys.modules.pop(__name__, None)
+    import telnetlib  # noqa: W0406
+    sys.modules[__name__] = telnetlib

--- a/telnetlib3/stream_reader.py
+++ b/telnetlib3/stream_reader.py
@@ -480,14 +480,12 @@ class TelnetReader:
         And therefore, a line does not yield for a stream containing a
         CR if it is not succeeded by NUL or LF.
 
-        ================= =====================
-        Given stream      readline() yields
-        ================= =====================
-        ``--\r\x00---``   ``--\r``, ``---`` *...*
-        ``--\r\n---``     ``--\r\n``, ``---`` *...*
-        ``--\n---``       ``--\n``, ``---`` *...*
-        ``--\r---``       ``--\r``, ``---`` *...*
-        ================= =====================
+        Given a stream containing the following sequences, ``readline()`` yields:
+
+        * ``\\r\\x00`` -- yields at ``\\r``
+        * ``\\r\\n`` -- yields at ``\\r\\n``
+        * ``\\n`` -- yields at ``\\n``
+        * ``\\r`` -- yields at ``\\r``
 
         If EOF is received before the termination of a line, the method will
         yield the partially read string.

--- a/telnetlib3/stream_writer.py
+++ b/telnetlib3/stream_writer.py
@@ -769,7 +769,7 @@ class TelnetWriter:
 
         elif self.cmd_received:
             # parse 3rd and final byte of IAC DO, DONT, WILL, WONT.
-            cmd, opt = self.cmd_received, byte  # type: ignore[assignment]
+            cmd, opt = self.cmd_received, byte
             self.log.debug("recv IAC %s %s", name_command(cmd), name_option(opt))
             try:
                 if cmd == DO:

--- a/telnetlib3/tests/test_telnetlib_import.py
+++ b/telnetlib3/tests/test_telnetlib_import.py
@@ -1,9 +1,5 @@
 """Test telnetlib shim and telnetlib3.telnetlib submodule imports."""
 
-# std imports
-import sys
-import sysconfig
-
 # 3rd party
 import pytest
 
@@ -54,10 +50,11 @@ def test_from_telnetlib3_import():
     assert callable(Telnet)
 
 
-def test_drop_in_support():
-    """``import telnetlib`` uses stdlib when available, shim otherwise."""
+def test_import_telnetlib_is_vendored_copy():
+    """``import telnetlib`` provides the vendored copy, not stdlib."""
     import telnetlib as telnetlib_
 
-    telnetlib_in_stdlib = sys.version_info < (3, 13)
-    telnetlib_is_stdlib = telnetlib_.__file__.startswith(sysconfig.get_path("stdlib"))
-    assert telnetlib_is_stdlib == telnetlib_in_stdlib
+    import telnetlib3.telnetlib
+
+    assert telnetlib_.IAC == telnetlib3.telnetlib.IAC
+    assert telnetlib_.Telnet is telnetlib3.telnetlib.Telnet

--- a/telnetlib3/tests/test_telnetlib_import.py
+++ b/telnetlib3/tests/test_telnetlib_import.py
@@ -1,0 +1,63 @@
+"""Test telnetlib shim and telnetlib3.telnetlib submodule imports."""
+
+# std imports
+import sys
+import sysconfig
+
+# 3rd party
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name, expected_type",
+    [
+        ("Telnet", type),
+        ("IAC", bytes),
+        ("WILL", bytes),
+        ("WONT", bytes),
+        ("DO", bytes),
+        ("DONT", bytes),
+        ("SB", bytes),
+        ("SE", bytes),
+        ("TELNET_PORT", int),
+    ],
+)
+def test_import_telnetlib_names(name, expected_type):
+    """``import telnetlib`` provides expected names and types."""
+    import telnetlib
+
+    assert isinstance(getattr(telnetlib, name), expected_type)
+
+
+def test_telnetlib_Telnet_instantiable():
+    """``Telnet()`` from the shim is instantiable."""
+    from telnetlib import Telnet
+
+    tn = Telnet()
+    assert tn is not None
+    tn.close()
+
+
+def test_import_telnetlib3_telnetlib():
+    """``import telnetlib3.telnetlib`` continues to work."""
+    import telnetlib3.telnetlib
+
+    assert telnetlib3.telnetlib.IAC is not None
+
+
+def test_from_telnetlib3_import():
+    """``from telnetlib3 import Telnet`` continues to work."""
+    from telnetlib3 import IAC, TELNET_PORT, Telnet
+
+    assert IAC is not None
+    assert TELNET_PORT == 23
+    assert callable(Telnet)
+
+
+def test_drop_in_support():
+    """``import telnetlib`` uses stdlib when available, shim otherwise."""
+    import telnetlib as telnetlib_
+
+    telnetlib_in_stdlib = sys.version_info < (3, 13)
+    telnetlib_is_stdlib = telnetlib_.__file__.startswith(sysconfig.get_path("stdlib"))
+    assert telnetlib_is_stdlib == telnetlib_in_stdlib

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 [testenv:docformatter]
 basepython = python3.13
 deps =
-    docformatter>=1.7.7
+    docformatter==1.7.7
     untokenize
 commands =
     docformatter \
@@ -63,7 +63,7 @@ commands =
 [testenv:docformatter_check]
 basepython = python3.13
 deps =
-    docformatter>=1.7.7
+    docformatter==1.7.7
     untokenize
 commands =
     docformatter \


### PR DESCRIPTION
- new shim 'telnetlib.py' in root project folder
- published by 'tool.hatch.build.targets.wheel.force-include'
- various import, old and new paths about it
