### PR TITLE
yield drain() after telnetlib3-client stdout.write()

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,8 @@
 History
 =======
+4.0.5
+  * enhancement: ``telnetlib3-client`` client shell now drains stdout.
+
 4.0.4
   * bugfix: servers using ``robot_check=True`` with ``encoding=False`` raised ``TypeError: buf
     expected bytes, got <class 'str'>``. ``telnetlib3-server`` now also accepts ``--encoding=False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "telnetlib3"
-version = "4.0.4"  # Keep in sync with telnetlib3/accessories.py::get_version !
+version = "4.0.5"  # Keep in sync with telnetlib3/accessories.py::get_version !
 description = " Python Telnet server and client CLI and Protocol library"
 readme = "README.rst"
 license = "ISC"

--- a/telnetlib3/accessories.py
+++ b/telnetlib3/accessories.py
@@ -42,7 +42,7 @@ PATIENCE_MESSAGES = [
 
 def get_version() -> str:
     """Return the current version of telnetlib3."""
-    return "4.0.4"  # keep in sync with pyproject.toml !
+    return "4.0.5"  # keep in sync with pyproject.toml !
 
 
 def encoding_from_lang(lang: str) -> Optional[str]:

--- a/telnetlib3/client_shell.py
+++ b/telnetlib3/client_shell.py
@@ -579,6 +579,8 @@ async def _raw_event_loop(
                 if raw_mode is None and want_repl():
                     state.reactivate_repl = True
             stdout.write(out.encode())
+            if hasattr(stdout, 'drain'):
+                await stdout.drain()
             _ts_file = telnet_writer.ctx.typescript_file
             if _ts_file is not None:
                 _ts_file.write(out)

--- a/telnetlib3/tests/test_client_shell.py
+++ b/telnetlib3/tests/test_client_shell.py
@@ -760,8 +760,7 @@ async def test_raw_event_loop_reactivates_repl() -> None:
     term = _make_term(writer)
     term.check_auto_mode = lambda switched_to_raw, last_will_echo: None
 
-    stdout = mock.Mock()
-    stdout.write = mock.Mock()
+    stdout = mock.Mock(spec=["write"])
 
     close_calls: list[str] = []
 
@@ -823,6 +822,7 @@ async def test_raw_event_loop_typescript_recording() -> None:
 
     stdout = mock.Mock()
     stdout.write = mock.Mock()
+    stdout.drain = mock.AsyncMock()
 
     state = _RawLoopState(
         switched_to_raw=True, last_will_echo=False, local_echo=False, linesep="\r\n"
@@ -839,6 +839,7 @@ async def test_raw_event_loop_typescript_recording() -> None:
         want_repl=lambda: False,
     )
     assert "hello world" in ts_buf.getvalue()
+    stdout.drain.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When integrating with downstream [telix](https://github.com/jquast/telix), which uses a pretty novel technique of delegating all of telnet client code to telnetlib3-client, except to use a modified object for the ``stdout.write()`` calls. This is sort of asynchronous by accident, that the OS/PTY buffers and chops up the write calls into multiple chunks of syscalls. However, telix needs some signal to know about the "edge boundary" -- when a write call begins and ends, so that it is able to interject and perform write calls of its own.